### PR TITLE
set docker host port to 80

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     volumes_from:
       - app
     ports:
-      - 80
+      - "80:80"
 
   cron:
     image: invoiceninja/invoiceninja


### PR DESCRIPTION
This will ensure that the nginx app will listen on port 80, rather than a random host port.
I am not sure if this was intended but was confusing to me.