### PR TITLE
Issue#1311

### DIFF
--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,48 +1,8 @@
 #!/bin/bash
 set -e
 
-
-# if we're linked to MySQL, and we're using the root user, and our linked
-# container has a default "root" password set up and passed through... :)
-: ${DB_USERNAME:=root}
-if [ "$DB_USERNAME" = 'root' ]; then
-	: ${DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
-fi
-
-echo "DB_USERNAME=$DB_USERNAME" >> .env
-echo "DB_PASSWORD=$DB_PASSWORD" >> .env
-echo "DB_HOST=$DB_HOST" >> .env
-echo "MAIL_DRIVER=$MAIL_DRIVER" >> .env
-echo "MAIL_PORT=$MAIL_PORT" >> .env
-echo "MAIL_HOST=$MAIL_HOST" >> .env
-echo "MAIL_USERNAME=$MAIL_USERNAME" >> .env
-echo "MAIL_PASSWORD=$MAIL_PASSWORD" >> .env
-echo "MAIL_FROM_ADDRESS=$MAIL_FROM_ADDRESS" >> .env
-echo "MAIL_FROM_NAME=$MAIL_FROM_NAME" >> .env
-
-if [ ! -d /var/www/app/storage ]; then
-	cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
-else
-	IN_STORAGE_BACKUP="$(ls /var/www/app/docker-backup-storage/)"
-	for path in $IN_STORAGE_BACKUP; do
-		if [ ! -e "/var/www/app/storage/$path" ]; then
-			cp -Rp "/var/www/app/docker-backup-storage/$path" "/var/www/app/storage/"
-		fi
-	done
-fi
-
-if [ ! -d /var/www/app/public/logo ]; then
-	cp -Rp /var/www/app/docker-backup-public-logo /var/www/app/public/logo
-else
-	IN_LOGO_BACKUP="$(ls /var/www/app/docker-backup-public-logo/)"
-	for path in $IN_LOGO_BACKUP; do
-		if [ ! -e "/var/www/app/public/logo/$path" ]; then
-			cp -Rp "/var/www/app/docker-backup-public-logo/$path" "/var/www/app/public/logo/"
-		fi
-	done
-fi
-
-chown www-data:www-data /var/www/app/.env
+rsync -a /var/www/app/docker-new-storage/ /var/www/app/storage/
+rsync -a /var/www/app/docker-new-public/ /var/www/app/public/
 
 # widely inspired from https://github.com/docker-library/wordpress/blob/c674e9ceedf582705e0ad8487c16b42b37a5e9da/fpm/docker-entrypoint.sh#L128
 TERM=dumb php -- "$DB_HOST" "$DB_USERNAME" "$DB_PASSWORD" "$DB_DATABASE" <<'EOPHP'

--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,6 +1,27 @@
 #!/bin/bash
 set -e
 
+
+# if we're linked to MySQL, and we're using the root user, and our linked
+# container has a default "root" password set up and passed through... :)
+: ${DB_USERNAME:=root}
+if [ "$DB_USERNAME" = 'root' ]; then
+	: ${DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
+fi
+
+echo "DB_USERNAME=$DB_USERNAME" >> .env
+echo "DB_PASSWORD=$DB_PASSWORD" >> .env
+echo "DB_HOST=$DB_HOST" >> .env
+echo "MAIL_DRIVER=$MAIL_DRIVER" >> .env
+echo "MAIL_PORT=$MAIL_PORT" >> .env
+echo "MAIL_HOST=$MAIL_HOST" >> .env
+echo "MAIL_USERNAME=$MAIL_USERNAME" >> .env
+echo "MAIL_PASSWORD=$MAIL_PASSWORD" >> .env
+echo "MAIL_FROM_ADDRESS=$MAIL_FROM_ADDRESS" >> .env
+echo "MAIL_FROM_NAME=$MAIL_FROM_NAME" >> .env
+
+chown www-data:www-data /var/www/app/.env
+
 rsync -a /var/www/app/docker-new-storage/ /var/www/app/storage/
 rsync -a /var/www/app/docker-new-public/ /var/www/app/public/
 


### PR DESCRIPTION
Fixed issues with the declared volumes:

Why do we declare a volume in docker? Because we want to persist that specific data during restarts of containers. The only data of invoice ninja that needs to be persistent are the `public/logo` & the `storage`.
The logo contains the logo and the storage contains log files we want to persist over restarts of the container.

The old code did the following:
`&& mv /var/www/invoiceninja-${INVOICENINJA_VERSION} /var/www/app \`
But because the directory `/var/www/app/public` is declared as a volume, the mv will not be executed on the directory so all files get update except for this specific directory. This happens when a container is restarted . This is no issue when starting up a **new container** because the new volumes will be created and the files will be moved correctly.

The suggested fix will treat the volumes correctly as persistent and copies over the directories of the volumes to a new location. Only with an entrypoint script volume files can be copied over so in the script the new files will be rsynced to the existing volumes. I used rsync because of the benefits but a simple copy can also be used. 
