### PR TITLE
Clear the .env file on every startup

### DIFF
--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -9,6 +9,8 @@ if [ "$DB_USERNAME" = 'root' ]; then
 	: ${DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
 fi
 
+echo "" > .env
+
 echo "DB_USERNAME=$DB_USERNAME" >> .env
 echo "DB_PASSWORD=$DB_PASSWORD" >> .env
 echo "DB_HOST=$DB_HOST" >> .env


### PR DESCRIPTION
Currently the variables get appended to the file each time there is a restart. This commit fixes this issue.