### PR TITLE
Remove duplicate ENV variables

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -36,8 +36,8 @@ services:
       trap "break;exit" SIGHUP SIGINT SIGTERM
       sleep 300s
       while /bin/true; do
-        DB_USERNAME=root DB_PASSWORD=pwd /usr/local/bin/php /var/www/app/artisan ninja:send-invoices
-        DB_USERNAME=root DB_PASSWORD=pwd /usr/local/bin/php /var/www/app/artisan ninja:send-reminders
+        /usr/local/bin/php /var/www/app/artisan ninja:send-invoices
+        /usr/local/bin/php /var/www/app/artisan ninja:send-reminders
         sleep 1d
       done
       EOF'


### PR DESCRIPTION
Since the variables are passed through an .env file they no longer need to passed directly, right?