### PR TITLE
Removal .env file use docker env instead

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,6 +51,8 @@ RUN curl -o invoiceninja.tar.gz -SL https://github.com/hillelcoren/invoice-ninja
 ######
 ENV DB_HOST mysql
 ENV DB_DATABASE ninja
+ENV DB_USERNAME ninja
+ENV DB_PASSWORD ninja
 ENV APP_KEY SomeRandomString
 ENV LOG errorlog
 ENV APP_DEBUG 0

--- a/README.md
+++ b/README.md
@@ -8,3 +8,28 @@ The first launch could be slow because we create all tables and seed the databas
 To make your data persistent, you have to mount `/var/www/app/public/logo` and `/var/www/app/storage`.
 
 All the supported environment variable can be found here https://github.com/invoiceninja/invoiceninja/blob/master/.env.example
+
+
+### Usage
+
+To run it:
+
+```
+docker run -d
+  -e APP_ENV='production'
+  -e APP_DEBUG=0
+  -e APP_URL='http://ninja.dev'
+  -e APP_KEY='SomeRandomStringSomeRandomString'
+  -e APP_CIPHER='AES-256-CBC'
+  -e DB_TYPE='mysql'
+  -e DB_STRICT='false'
+  -e DB_HOST='localhost'
+  -e DB_DATABASE='ninja'
+  -e DB_USERNAME='ninja'
+  -e DB_PASSWORD='ninja'
+  -p '80:80'
+  invoiceninja/invoiceninja
+```
+A list of environment variables can be found [here](https://github.com/invoiceninja/invoiceninja/blob/master/.env.example)
+
+

--- a/app-entrypoint.sh
+++ b/app-entrypoint.sh
@@ -1,25 +1,6 @@
 #!/bin/bash
 set -e
 
-
-# if we're linked to MySQL, and we're using the root user, and our linked
-# container has a default "root" password set up and passed through... :)
-: ${DB_USERNAME:=root}
-if [ "$DB_USERNAME" = 'root' ]; then
-	: ${DB_PASSWORD:=$MYSQL_ENV_MYSQL_ROOT_PASSWORD}
-fi
-
-echo "DB_USERNAME=$DB_USERNAME" >> .env
-echo "DB_PASSWORD=$DB_PASSWORD" >> .env
-echo "DB_HOST=$DB_HOST" >> .env
-echo "MAIL_DRIVER=$MAIL_DRIVER" >> .env
-echo "MAIL_PORT=$MAIL_PORT" >> .env
-echo "MAIL_HOST=$MAIL_HOST" >> .env
-echo "MAIL_USERNAME=$MAIL_USERNAME" >> .env
-echo "MAIL_PASSWORD=$MAIL_PASSWORD" >> .env
-echo "MAIL_FROM_ADDRESS=$MAIL_FROM_ADDRESS" >> .env
-echo "MAIL_FROM_NAME=$MAIL_FROM_NAME" >> .env
-
 if [ ! -d /var/www/app/storage ]; then
 	cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
 else
@@ -41,8 +22,6 @@ else
 		fi
 	done
 fi
-
-chown www-data:www-data /var/www/app/.env
 
 # widely inspired from https://github.com/docker-library/wordpress/blob/c674e9ceedf582705e0ad8487c16b42b37a5e9da/fpm/docker-entrypoint.sh#L128
 TERM=dumb php -- "$DB_HOST" "$DB_USERNAME" "$DB_PASSWORD" "$DB_DATABASE" <<'EOPHP'


### PR DESCRIPTION
In response of https://github.com/invoiceninja/dockerfiles/pull/37:

Instead of creating a .env file via app-entrypoint.sh, the env variables are set through docker.
Also added some doc.