### PR TITLE
removed unused exposed port

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -66,8 +66,6 @@ VOLUME /var/www/app/public
 
 WORKDIR /var/www/app
 
-EXPOSE 80
-
 COPY app-entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 


### PR DESCRIPTION
The base image of php:7.0-fpm already exposes port 9000. The removed port 80 is useless AFAIK.