### PR TITLE
Issue #41: Users shouldn't commit .env files to the repo...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Ignore environment variables.
+.env

--- a/example/example.env
+++ b/example/example.env
@@ -1,5 +1,4 @@
-
-
+# Copy this file to the repo root as '.env' and populate with desired values
 APP_DEBUG=1
 APP_URL=http://localhost:8000
 DB_USERNAME=root


### PR DESCRIPTION
... so a .gitignore is added to make sure any file by the name '.env' gets ignored. The existing .env is renamed to example.env with a comment clarifying its use.