### PR TITLE
Mount MySQL volume to make data persistent

### DIFF
--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -6,6 +6,8 @@ services:
     environment:
       MYSQL_DATABASE: ninja
       MYSQL_ROOT_PASSWORD: pwd
+    volumes:
+      - ./var/mysql:/var/lib/mysql
 
   app:
     image: invoiceninja/invoiceninja


### PR DESCRIPTION
When shutting down docker to for example open an other project docker environment, the mounted volume makes sure the database is being persisted.