### PR TITLE
Fixed MySQL volume mount to be from root.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The easiest way to test Invoice Ninja with docker is by copying the example dire
 
 To make your data persistent, you have to mount `/var/www/app/public/logo` and `/var/www/app/storage`.
 
+The MySQL volume is already mounted to `/srv/invoiceninja/data` so to persist data stored in MySQL (ex. invoices).
+
 All the supported environment variable can be found here https://github.com/invoiceninja/invoiceninja/blob/master/.env.example
 
 

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       MYSQL_DATABASE: ninja
       MYSQL_ROOT_PASSWORD: pwd
     volumes:
-      - /srv/invoiceninja/mysql:/var/lib/mysql
+      - /srv/invoiceninja/data:/var/lib/mysql
 
   app:
     image: invoiceninja/invoiceninja

--- a/example/docker-compose.yml
+++ b/example/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       MYSQL_DATABASE: ninja
       MYSQL_ROOT_PASSWORD: pwd
     volumes:
-      - ./var/mysql:/var/lib/mysql
+      - /srv/invoiceninja/mysql:/var/lib/mysql
 
   app:
     image: invoiceninja/invoiceninja


### PR DESCRIPTION
I noticed that the example docker-compose.yml file has the MySQL volume mounted from the current directory on the host side. I'm assuming this is a mistake, since this isn't normally where you'd mount your persisted data when using Docker to host applications. The convention is to use a directory in the root directory, usually /var or /srv.

I changed it to use /srv/invoiceninja/data instead, with the invoiceninja directory to prevent it from clashing with other Docker hosted applications. An example of this convention used in the industry is with [GitLab's Docker instructions](https://docs.gitlab.com/omnibus/docker/).