### PR TITLE
Create the database and database on start

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update \
         zlib1g-dev git libgmp-dev unzip \
         libfreetype6-dev libjpeg62-turbo-dev libpng-dev \
         build-essential chrpath libssl-dev libxft-dev \
-        libfreetype6 libfontconfig1 libfontconfig1-dev \
+        libfreetype6 libfontconfig1 libfontconfig1-dev mysql-client \
     && ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/local/include/ \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-configure gmp \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,32 @@
 #!/bin/bash
 set -e
 
+DB_PORT=3306
+mysqlcmd="mysql -uroot -h ${DB_HOST} -P ${DB_PORT} -p${MYSQL_ROOT_PASSWORD} "
+
+function wait_for_db() {
+  while [ ! "$(mysqladmin ping -h ${DB_HOST} -P ${DB_PORT} -u root \
+              --password="${MYSQL_ROOT_PASSWORD}" --silent --connect_timeout=3)" ]; do
+    echo "Database server is not available. Waiting 2 seconds..."
+    sleep 2
+  done
+  echo "Database server is up !"
+}
+
+function create_db() {
+  echo "Creating database..."
+  $mysqlcmd -e "CREATE DATABASE IF NOT EXISTS ${DB_DATABASE};"
+  [ $? -gt 0 ] && echo "Couldn't create database !!" && exit 23
+	echo "Creating database user and assigning permissions..."
+  $mysqlcmd -e " GRANT ALL ON ${DB_DATABASE}.* to '${DB_USERNAME}'@'%' identified by '${DB_PASSWORD}'";
+  [ $? -gt 0 ] && echo "Couldn't create database user !!" && exit 2
+	echo "Done."
+}
+
+#Wait for database to come up
+wait_for_db
+create_db
+
 if [ ! -d /var/www/app/storage ]; then
 	cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
 else

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -16,10 +16,10 @@ function wait_for_db() {
 function create_db() {
   echo "Creating database..."
   $mysqlcmd -e "CREATE DATABASE IF NOT EXISTS ${DB_DATABASE};"
-  [ $? -gt 0 ] && echo "Couldn't create database !!" && exit 23
+  [ $? -gt 0 ] && echo "Couldn't create database !!" && exit 1
 	echo "Creating database user and assigning permissions..."
   $mysqlcmd -e " GRANT ALL ON ${DB_DATABASE}.* to '${DB_USERNAME}'@'%' identified by '${DB_PASSWORD}'";
-  [ $? -gt 0 ] && echo "Couldn't create database user !!" && exit 2
+  [ $? -gt 0 ] && echo "Couldn't create database user !!" && exit 1
 	echo "Done."
 }
 


### PR DESCRIPTION
Hi, 

To avoid having the user manually create the database and database user on the database container, this PR adds code to _entrypoint.sh_ to automatically create the database and user needed to setup the application.

It uses the environment variables DB_HOST, DB_DATABASE, DB_USERNAME, etc to do the database setup.