### PR TITLE
Improvements for Alpine image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,16 +38,8 @@ RUN curl -o ${PHANTOMJS}.tar.bz2 -SL https://bitbucket.org/ariya/phantomjs/downl
     && ln -sf /usr/local/share/${PHANTOMJS}/bin/phantomjs /usr/local/bin \
     && rm -rf /var/lib/apt/lists/*
 
-# set recommended PHP.ini settings
-# see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+COPY ./config/php.ini /usr/local/etc/php/php.ini
+COPY ./config/php-cli.ini /usr/local/etc/php/php-cli.ini
 
 #####
 # DOWNLOAD AND INSTALL INVOICE NINJA

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+ifndef TAG
+$(error The TAG variable is missing.)
+endif
+
+# Docker Hub namespace
+HUB_NAMESPACE="codedge"
+
+# Image name
+IMAGE="invoiceninja"
+
+
+# Building the IN based on alpine image, tag the image.
+# The 'latest' tag is also being assigned to this image.
+.PHONY: build-alpine
+build-alpine:
+	$(info Make: Building "$(TAG)" tagged images.)
+	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile .
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${TAG} ${HUB_NAMESPACE}/${IMAGE}:latest
+	$(info Make: Done.)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ $(error The TAG variable is missing.)
 endif
 
 # Docker Hub namespace
-HUB_NAMESPACE="codedge"
+HUB_NAMESPACE="invoiceninja"
 
 # Image name
 IMAGE="invoiceninja"

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,6 +1,6 @@
-ARG PHP_IMAGE_TAG=7.2-fpm-alpine
+ARG PHP_VERSION=7.2
 
-FROM php:${PHP_IMAGE_TAG}
+FROM php:${PHP_VERSION}-fpm-alpine
 
 LABEL maintainer="Samuel Laulhau <sam@lalop.co>"
 
@@ -9,26 +9,35 @@ LABEL maintainer="Samuel Laulhau <sam@lalop.co>"
 #####
 WORKDIR /var/www/app
 
+COPY ./alpine/entrypoint.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
 ENV PHANTOMJS phantomjs-2.1.1-linux-x86_64
 
-RUN apk update \
- && apk add --no-cache \
-    coreutils \
-    chrpath \
-    fontconfig \
-    git \
+RUN set -eux; \
+    apk add --no-cache \
     gmp-dev \
     freetype-dev \
+    libarchive-tools \
     libjpeg-turbo-dev \
-    libpng-dev
+    libpng-dev \
+    libwebp-dev\ 
+    libzip-dev
 
-RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
-    && docker-php-ext-configure gmp \
-    && docker-php-ext-install iconv mbstring pdo pdo_mysql zip gd gmp opcache \
-    && echo "php_admin_value[error_reporting] = E_ALL & ~E_NOTICE & ~E_WARNING & ~E_STRICT & ~E_DEPRECATED">>/usr/local/etc/php-fpm.d/www.conf
+RUN docker-php-ext-configure gd --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include --with-webp-dir=/usr/include --with-freetype-dir=/usr/include/; \
+	docker-php-ext-configure zip --with-libzip; \
+	docker-php-ext-install -j$(nproc) \
+       iconv \
+       gd \
+       gmp \
+       mbstring \
+       opcache \
+       pdo \
+       pdo_mysql \
+       zip
     
 RUN cd /usr/share \
-    && curl -L https://github.com/Overbryd/docker-phantomjs-alpine/releases/download/2.11/phantomjs-alpine-x86_64.tar.bz2 | tar xj \
+    && curl -s -L https://github.com/Overbryd/docker-phantomjs-alpine/releases/download/2.11/phantomjs-alpine-x86_64.tar.bz2 | tar xj \
     && ln -s /usr/share/phantomjs/phantomjs /usr/local/bin/phantomjs
 
 COPY ./config/php/php.ini /usr/local/etc/php/php.ini
@@ -42,9 +51,10 @@ RUN addgroup -S "$IN_USER" && \
     --disabled-password \
     --gecos "" \
     --home "$(pwd)" \
-    --ingroup "$IN_USER" \
+    --ingroup "$IN_USER" \ 
     --no-create-home \
-    "$IN_USER" && \
+    "$IN_USER"; \
+    addgroup "$IN_USER" www-data; \
     chown -R "$IN_USER":"$IN_USER" .
 
 USER $IN_USER
@@ -53,19 +63,14 @@ USER $IN_USER
 ENV INVOICENINJA_VERSION 4.5.18
 
 RUN curl -s -o /tmp/ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJA_VERSION}.zip \
-    && unzip /tmp/ninja.zip -d /var/www/app -q \
-    && rm /tmp/ninja.zip
-
-RUN echo "$(pwd)" && ls -la .
-
-
-
-RUN mv /var/www/app/storage /var/www/app/docker-backup-storage  \
+    && bsdtar --strip-components=1 -C /var/www/app -xf /tmp/ninja.zip \
+    && rm /tmp/ninja.zip \
+    && mv /var/www/app/storage /var/www/app/docker-backup-storage  \
     && mv /var/www/app/public /var/www/app/docker-backup-public  \
     && mkdir -p /var/www/app/public/logo /var/www/app/storage \
     && touch /var/www/app/.env \
     && chmod -R 755 /var/www/app/storage  \
-    && rm -rf /var/www/app/docs /var/www/app/tests /var/www/ninja
+    && rm -rf /var/www/app/docs /var/www/app/tests
 
 ######
 # DEFAULT ENV
@@ -78,8 +83,5 @@ ENV PHANTOMJS_BIN_PATH /usr/local/bin/phantomjs
 # Use to be mounted into nginx
 VOLUME /var/www/app/public
 
-COPY entrypoint.sh /usr/local/bin/invoice-entrypoint
-# RUN chmod +x /usr/local/bin/invoice-entrypoint
-
-ENTRYPOINT ["invoice-entrypoint"]
+ENTRYPOINT ["docker-entrypoint"]
 CMD ["php-fpm"]

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -3,7 +3,7 @@ ARG INVOICENINJA_VERSION
 
 FROM php:${PHP_VERSION}-fpm-alpine
 
-LABEL maintainer="Samuel Laulhau <sam@lalop.co>"
+LABEL maintainer="Samuel Laulhau <sam@lalop.co>,  Holger Lösken <holger.loesken@codedge.de>"
 
 #####
 # SYSTEM REQUIREMENT

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,5 @@
 ARG PHP_IMAGE_TAG=7.2-fpm-alpine
+
 FROM php:${PHP_IMAGE_TAG}
 
 LABEL maintainer="Samuel Laulhau <sam@lalop.co>"
@@ -6,10 +7,20 @@ LABEL maintainer="Samuel Laulhau <sam@lalop.co>"
 #####
 # SYSTEM REQUIREMENT
 #####
+WORKDIR /var/www/app
+
 ENV PHANTOMJS phantomjs-2.1.1-linux-x86_64
+
 RUN apk update \
- && apk add --no-cache git gmp-dev freetype-dev libjpeg-turbo-dev \
-            coreutils chrpath fontconfig libpng-dev
+ && apk add --no-cache \
+    coreutils \
+    chrpath \
+    fontconfig \
+    git \
+    gmp-dev \
+    freetype-dev \
+    libjpeg-turbo-dev \
+    libpng-dev
 
 RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-configure gmp \
@@ -17,32 +28,39 @@ RUN docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-di
     && echo "php_admin_value[error_reporting] = E_ALL & ~E_NOTICE & ~E_WARNING & ~E_STRICT & ~E_DEPRECATED">>/usr/local/etc/php-fpm.d/www.conf
     
 RUN cd /usr/share \
-    && curl  -L https://github.com/Overbryd/docker-phantomjs-alpine/releases/download/2.11/phantomjs-alpine-x86_64.tar.bz2 | tar xj \
+    && curl -L https://github.com/Overbryd/docker-phantomjs-alpine/releases/download/2.11/phantomjs-alpine-x86_64.tar.bz2 | tar xj \
     && ln -s /usr/share/phantomjs/phantomjs /usr/local/bin/phantomjs
-    
 
-# set recommended PHP.ini settings
-# see https://secure.php.net/manual/en/opcache.installation.php
-RUN { \
-		echo 'opcache.memory_consumption=128'; \
-		echo 'opcache.interned_strings_buffer=8'; \
-		echo 'opcache.max_accelerated_files=4000'; \
-		echo 'opcache.revalidate_freq=60'; \
-		echo 'opcache.fast_shutdown=1'; \
-		echo 'opcache.enable_cli=1'; \
-} > /usr/local/etc/php/conf.d/opcache-recommended.ini
+COPY ./config/php/php.ini /usr/local/etc/php/php.ini
+COPY ./config/php/php-cli.ini /usr/local/etc/php/php-cli.ini
 
-#####
-# DOWNLOAD AND INSTALL INVOICE NINJA
-#####
+# Separate user
+ENV IN_USER=invoiceninja
 
+RUN addgroup -S "$IN_USER" && \
+    adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "$(pwd)" \
+    --ingroup "$IN_USER" \
+    --no-create-home \
+    "$IN_USER" && \
+    chown -R "$IN_USER":"$IN_USER" .
+
+USER $IN_USER
+
+# Download and install IN
 ENV INVOICENINJA_VERSION 4.5.18
 
-RUN curl -o ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJA_VERSION}.zip \
-    && unzip ninja.zip -d /var/www/ \
-    && rm ninja.zip \
-    && mv /var/www/ninja /var/www/app  \
-    && mv /var/www/app/storage /var/www/app/docker-backup-storage  \
+RUN curl -s -o /tmp/ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJA_VERSION}.zip \
+    && unzip /tmp/ninja.zip -d /var/www/app -q \
+    && rm /tmp/ninja.zip
+
+RUN echo "$(pwd)" && ls -la .
+
+
+
+RUN mv /var/www/app/storage /var/www/app/docker-backup-storage  \
     && mv /var/www/app/public /var/www/app/docker-backup-public  \
     && mkdir -p /var/www/app/public/logo /var/www/app/storage \
     && touch /var/www/app/.env \
@@ -57,10 +75,8 @@ ENV SELF_UPDATER_SOURCE ''
 ENV PHANTOMJS_BIN_PATH /usr/local/bin/phantomjs
 
 
-#use to be mounted into nginx for exemple
+# Use to be mounted into nginx
 VOLUME /var/www/app/public
-
-WORKDIR /var/www/app
 
 COPY entrypoint.sh /usr/local/bin/invoice-entrypoint
 # RUN chmod +x /usr/local/bin/invoice-entrypoint

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,5 @@
 ARG PHP_VERSION=7.2
+ARG INVOICENINJA_VERSION
 
 FROM php:${PHP_VERSION}-fpm-alpine
 
@@ -12,7 +13,7 @@ WORKDIR /var/www/app
 COPY ./alpine/entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 
-ENV PHANTOMJS phantomjs-2.1.1-linux-x86_64
+ENV PHANTOMJS="phantomjs-2.1.1-linux-x86_64"
 
 RUN set -eux; \
     apk add --no-cache \
@@ -60,7 +61,7 @@ RUN addgroup -S "$IN_USER" && \
 USER $IN_USER
 
 # Download and install IN
-ENV INVOICENINJA_VERSION 4.5.18
+ENV INVOICENINJA_VERSION="${INVOICENINJA_VERSION}"
 
 RUN curl -s -o /tmp/ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJA_VERSION}.zip \
     && bsdtar --strip-components=1 -C /var/www/app -xf /tmp/ninja.zip \
@@ -75,9 +76,9 @@ RUN curl -s -o /tmp/ninja.zip -SL https://download.invoiceninja.com/ninja-v${INV
 ######
 # DEFAULT ENV
 ######
-ENV LOG errorlog
-ENV SELF_UPDATER_SOURCE ''
-ENV PHANTOMJS_BIN_PATH /usr/local/bin/phantomjs
+ENV LOG=errorlog
+ENV SELF_UPDATER_SOURCE=""
+ENV PHANTOMJS_BIN_PATH="/usr/local/bin/phantomjs"
 
 
 # Use to be mounted into nginx

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,36 +1,44 @@
 #!/usr/bin/env sh
 set -e
 
-if [ ! -d /var/www/app/storage ]; then
-    cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
-else
-    IN_STORAGE_BACKUP="$(ls /var/www/app/docker-backup-storage/)"
-    for path in $IN_STORAGE_BACKUP; do
-        if [ ! -e "/var/www/app/storage/$path" ]; then
-            cp -Rp "/var/www/app/docker-backup-storage/$path" "/var/www/app/storage/"
-        fi
-    done
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
 fi
 
-if [ ! -d /var/www/app/public/logo ]; then
-    cp -Rp /var/www/app/docker-backup-public/logo /var/www/app/public/logo
-else
-    IN_LOGO_BACKUP="$(ls /var/www/app/docker-backup-public/logo/)"
-    for path in $IN_LOGO_BACKUP; do
-        if [ ! -e "/var/www/app/public/logo/$path" ]; then
-            cp -Rp "/var/www/app/docker-backup-public/logo/$path" "/var/www/app/public/logo/"
-        fi
-    done
-fi
 
-# compare public volume version with image version
-if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
-  cp -Rp /var/www/app/docker-backup-public/* /var/www/app/public/
-  echo $INVOICENINJA_VERSION > /var/www/app/public/version
-fi
+if [ "$1" = 'php-fpm' ] || [ "$1" = 'bin/console' ]; then
+    if [ ! -d /var/www/app/storage ]; then
+        cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
+    else
+        IN_STORAGE_BACKUP="$(ls /var/www/app/docker-backup-storage/)"
+        for path in $IN_STORAGE_BACKUP; do
+            if [ ! -e "/var/www/app/storage/$path" ]; then
+                cp -Rp "/var/www/app/docker-backup-storage/$path" "/var/www/app/storage/"
+            fi
+        done
+    fi
 
-# Set permission for mounted directories
-chown invoiceninja:www-data /var/www/app/storage
-chown invoiceninja:www-data /var/www/app/public/logo
+    if [ ! -d /var/www/app/public/logo ]; then
+        cp -Rp /var/www/app/docker-backup-public/logo /var/www/app/public/logo
+    else
+        IN_LOGO_BACKUP="$(ls /var/www/app/docker-backup-public/logo/)"
+        for path in $IN_LOGO_BACKUP; do
+            if [ ! -e "/var/www/app/public/logo/$path" ]; then
+                cp -Rp "/var/www/app/docker-backup-public/logo/$path" "/var/www/app/public/logo/"
+            fi
+        done
+    fi
+
+    # compare public volume version with image version
+    if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
+        cp -au /var/www/app/docker-backup-public/* /var/www/app/public/
+        echo $INVOICENINJA_VERSION > /var/www/app/public/version
+    fi
+
+    # Set permission for mounted directories
+    chown invoiceninja:www-data /var/www/app/storage
+    chown invoiceninja:www-data /var/www/app/public
+fi
 
 exec docker-php-entrypoint "$@"

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -1,26 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env sh
 set -e
 
 if [ ! -d /var/www/app/storage ]; then
-	cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
+    cp -Rp /var/www/app/docker-backup-storage /var/www/app/storage
 else
-	IN_STORAGE_BACKUP="$(ls /var/www/app/docker-backup-storage/)"
-	for path in $IN_STORAGE_BACKUP; do
-		if [ ! -e "/var/www/app/storage/$path" ]; then
-			cp -Rp "/var/www/app/docker-backup-storage/$path" "/var/www/app/storage/"
-		fi
-	done
+    IN_STORAGE_BACKUP="$(ls /var/www/app/docker-backup-storage/)"
+    for path in $IN_STORAGE_BACKUP; do
+        if [ ! -e "/var/www/app/storage/$path" ]; then
+            cp -Rp "/var/www/app/docker-backup-storage/$path" "/var/www/app/storage/"
+        fi
+    done
 fi
 
 if [ ! -d /var/www/app/public/logo ]; then
-	cp -Rp /var/www/app/docker-backup-public/logo /var/www/app/public/logo
+    cp -Rp /var/www/app/docker-backup-public/logo /var/www/app/public/logo
 else
-	IN_LOGO_BACKUP="$(ls /var/www/app/docker-backup-public/logo/)"
-	for path in $IN_LOGO_BACKUP; do
-		if [ ! -e "/var/www/app/public/logo/$path" ]; then
-			cp -Rp "/var/www/app/docker-backup-public/logo/$path" "/var/www/app/public/logo/"
-		fi
-	done
+    IN_LOGO_BACKUP="$(ls /var/www/app/docker-backup-public/logo/)"
+    for path in $IN_LOGO_BACKUP; do
+        if [ ! -e "/var/www/app/public/logo/$path" ]; then
+            cp -Rp "/var/www/app/docker-backup-public/logo/$path" "/var/www/app/public/logo/"
+        fi
+    done
 fi
 
 # compare public volume version with image version
@@ -30,18 +30,8 @@ if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /
   echo $INVOICENINJA_VERSION > /var/www/app/public/version
 fi
 
-# fix permission for monted directories
-chown www-data:www-data /var/www/app/storage
-chown www-data:www-data /var/www/app/public/logo
+# Set permission for mounted directories
+chown invoiceninja:www-data /var/www/app/storage
+chown invoiceninja:www-data /var/www/app/public/logo
 
-
-#php artisan optimize --force
-#php artisan migrate --force
-
-#if [ ! -e "/var/www/app/is-seeded" ]; then
-	#php artisan db:seed --force
-	#touch "/var/www/app/is-seeded"
-#fi
-
-echo 'start'
-exec "$@"
+exec docker-php-entrypoint "$@"

--- a/alpine/entrypoint.sh
+++ b/alpine/entrypoint.sh
@@ -25,7 +25,6 @@ fi
 
 # compare public volume version with image version
 if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
-  echo 'clone public directory'
   cp -Rp /var/www/app/docker-backup-public/* /var/www/app/public/
   echo $INVOICENINJA_VERSION > /var/www/app/public/version
 fi

--- a/config/php/php-cli.ini
+++ b/config/php/php-cli.ini
@@ -1,6 +1,8 @@
 session.auto_start = Off
 short_open_tag = Off
 
+error_reporting = E_ALL & ~E_NOTICE & ~E_WARNING & ~E_STRICT & ~E_DEPRECATED
+
 opcache.enable_cli=1
 opcache.fast_shutdown=1
 opcache.memory_consumption=128

--- a/config/php/php-cli.ini
+++ b/config/php/php-cli.ini
@@ -1,0 +1,16 @@
+session.auto_start = Off
+short_open_tag = Off
+
+opcache.enable_cli=1
+opcache.fast_shutdown=1
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=60
+# http://symfony.com/doc/current/performance.html
+realpath_cache_size = 4096K
+realpath_cache_ttl = 600
+
+memory_limit = 2G
+post_max_size = 6M
+upload_max_filesize = 5M

--- a/config/php/php.ini
+++ b/config/php/php.ini
@@ -1,6 +1,8 @@
 session.auto_start = Off
 short_open_tag = Off
 
+error_reporting = E_ALL & ~E_NOTICE & ~E_WARNING & ~E_STRICT & ~E_DEPRECATED
+
 opcache.enable_cli=1
 opcache.fast_shutdown=1
 opcache.memory_consumption=128

--- a/config/php/php.ini
+++ b/config/php/php.ini
@@ -1,0 +1,15 @@
+session.auto_start = Off
+short_open_tag = Off
+
+opcache.enable_cli=1
+opcache.fast_shutdown=1
+opcache.memory_consumption=128
+opcache.interned_strings_buffer=8
+opcache.max_accelerated_files=4000
+opcache.revalidate_freq=60
+# http://symfony.com/doc/current/performance.html
+realpath_cache_size = 4096K
+realpath_cache_ttl = 600
+
+post_max_size = 6M
+upload_max_filesize = 5M


### PR DESCRIPTION
This PR introduces some bigger changes for the docker `alpine` image.

**Build image via `Makefile`**

This is some first step towards automated build. The build command for the `alpine` based image is encapsulated into a _Makefile_ and can be called via `make build-alpine TAG="<IN_VERSION>"` from the project root dir.

**Move php config into separate file**

The configuration for php has been moved into a separate file, split into `cli` and `non-cli` version. This file can easily be copied into the docker images  and do not clutter the Dockerfile itself.

**Run as non-root**

Fix #99 

IN is run as a separate user called `invoiceninja` inside the docker image. All files are `chown`ed to this user, some have also `www-data` as group to be writeable by the web server.

As this has some implications for the mounted folders `public` and `storage`, I still need to update the readme. I am just waiting to get #118 merged in.
// ping @lalop 😄 

**Ownership for `/var/www/app`**

Fix #126 

The folder `/var/www/app` is properly owned by the new `invoiceninja` user

**Various other alpine-related issues**

- Resolve #102: I cannot find any error in the current `alpine` version running with 4.5.18.
- Issue #119: I cannot confirm this problem in the `alpine` image.

I built the image on Linux (Debian 10) and MacOSX Catalina 10.15.4 without problems and run it currently for own business.
