### PR TITLE
Explanation how to view log files

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ docker run -d \
   -e DB_DATABASE='ninja' \
   -e DB_USERNAME='ninja' \
   -e DB_PASSWORD='ninja' \
-  -e LOG=errorlog \
   -p '9000:9000' \
   invoiceninja/invoiceninja
 ```
@@ -60,7 +59,19 @@ If you are running the `docker-compose` setup you can output all logs, from all 
 docker-compose logs -f
 ```
 
-If you better want a physical log file in in your `storage/logs` folder, just remove this line `-e LOG=errorlog` from the [usage](#usage) command or change it to `-e LOG=single`. Both works.
+If you better want a physical log file in in your `storage/logs` folder, just add `-e LOG=single` to the [usage](#usage) command. 
+Or add an environment variable 
+
+```yml
+...
+environment:
+  LOG: single
+...
+```
+
+to your `docker-compose.yml`.
+
+This generated log file will only hold Invoice Ninja information.
 
 
 ### Known issues

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ docker run -d \
   -e DB_DATABASE='ninja' \
   -e DB_USERNAME='ninja' \
   -e DB_PASSWORD='ninja' \
+  -e LOG=errorlog \
   -p '9000:9000' \
   invoiceninja/invoiceninja
 ```
@@ -35,6 +36,32 @@ A ready to use docker-compose configuration can be found at [`./docker-compose`]
 Run `cp .env.example .env` and change the environment variables as needed.
 The file assumes that all your persistent data is mounted from `/srv/invoiceninja/`.
 Once started, the application should be accessible at http://localhost:8000.
+
+
+## Debugging your Docker setup
+
+Even when running your Invoice Ninja setup with Docker - errors can occur. Depending on where the error happens - the webserver, Invoice Ninja or the database - different log files can be responsible. 
+
+### Show logs without `docker-compose`
+
+If you are not running the `docker-compose` you first need to find the container id for your php container with `docker ps`. Then you can run
+
+```shell
+docker logs -f <CONTAINER NAME>
+```
+
+This gives you a constant output of the log files for the php container.
+
+### Show logs with `docker-compose`
+
+If you are running the `docker-compose` setup you can output all logs, from all containers, with the following command
+
+```shell
+docker-compose logs -f
+```
+
+If you better want a physical log file in in your `storage/logs` folder, just remove this line `-e LOG=errorlog` from the [usage](#usage) command or change it to `-e LOG=single`. Both works.
+
 
 ### Known issues
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -52,6 +52,7 @@ RUN curl -o ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJ
 ######
 # DEFAULT ENV
 ######
+ENV LOG errorlog
 ENV SELF_UPDATER_SOURCE ''
 ENV PHANTOMJS_BIN_PATH /usr/local/bin/phantomjs
 

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -52,7 +52,6 @@ RUN curl -o ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJ
 ######
 # DEFAULT ENV
 ######
-ENV LOG errorlog
 ENV SELF_UPDATER_SOURCE ''
 ENV PHANTOMJS_BIN_PATH /usr/local/bin/phantomjs
 


### PR DESCRIPTION
Fix #137

* Better description how to find log files
  * Show the users how view logs w/ `docker-compose logs` or `docker logs`
* Change default log to file but can be overridden by env var

⚠️ ~This depends on a change in #139, as only if this gets merged, the values from `.env.example` are used when building the containers.~

**Background of this PR**

In the current situation the user needs to know how to view log files from a docker container, as the log driver is set to `errorlog`.
The user must be proficient with Docker to run either `docker logs` or `docker-compose logs`. 

The issue #137 showed, that neither all users are proficient, nor do they conclude that when in Docker context, there is probably no log file. No, they are still looking for a file.

[**Example 1**](https://github.com/invoiceninja/dockerfiles/issues/137#issuecomment-626303684)
> [...]and were told to "check their log files".
> So I tried to check my log files and discovered I don't have any.

[**Example 2**](https://github.com/invoiceninja/dockerfiles/issues/137#issuecomment-626305119)
> If it is redirected to docker's output / error, I assume output would be redirected to /dev/stdout and errors to /dev/stderr?
> Put another way... Do you get logs in your container? Is it just me?

So this PR should add more documentation, which it does, and it should set a default, that users probably embrace more - nonetheless it gives enough configuration for proficient users to configure the application as they like.