### PR TITLE
Fix wrong argument scope, pull correct IN version

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,5 +1,4 @@
 ARG PHP_VERSION=7.2
-ARG INVOICENINJA_VERSION
 
 FROM php:${PHP_VERSION}-fpm-alpine
 
@@ -8,6 +7,7 @@ LABEL maintainer="Samuel Laulhau <sam@lalop.co>, Holger Lösken <holger.loesken@
 #####
 # SYSTEM REQUIREMENT
 #####
+ARG INVOICENINJA_VERSION
 WORKDIR /var/www/app
 
 COPY ./alpine/entrypoint.sh /usr/local/bin/docker-entrypoint

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,5 +1,4 @@
 ARG PHP_VERSION=7.2
-ARG INVOICENINJA_VERSION
 
 FROM php:${PHP_VERSION}-fpm-stretch
 
@@ -8,6 +7,7 @@ LABEL maintainer="Samuel Laulhau <sam@lalop.co>, Holger Lösken <holger.loesken@
 #####
 # SYSTEM REQUIREMENT
 #####
+ARG INVOICENINJA_VERSION
 COPY ./debian/entrypoint.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 


### PR DESCRIPTION
This fixes a bug where the tag argument is not properly scoped, before `FROM`, and so the improper IN version is pulled.