### PR TITLE
Build docker images for v5

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -19,16 +19,22 @@ jobs:
           id: vars
           run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})
 
-        - name: Build image from alpine
+        - name: Build image from alpine - v5
+          run: make build-alpine-v5 TAG="${{steps.vars.outputs.tag}}"
+
+        - name: Push alpine-based image - v5
+          run: make push-alpine-v5 TAG="${{steps.vars.outputs.tag}}"
+
+        - name: Build image from alpine - v4
           run: make build-alpine TAG="${{steps.vars.outputs.tag}}"
 
-        - name: Push alpine-based image
+        - name: Push alpine-based image - v4
           run: make push-alpine TAG="${{steps.vars.outputs.tag}}"
 
-        - name: Build image from debian
+        - name: Build image from debian - v4
           run: make build-debian TAG="${{steps.vars.outputs.tag}}"
 
-        - name: Push debian-based image
+        - name: Push debian-based image - v4
           run: make push-debian TAG="${{steps.vars.outputs.tag}}"
 
         - name: Logout from DockerHub

--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,9 @@ endif
 build-alpine-v5:
 ifneq ($(IS_V5),)
 	$(info Make: Building "$(TAG)" tagged images from alpine.)
-	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile_v5 .
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine-5
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:latest
+	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile_v5 .
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${TAG} ${HUB_NAMESPACE}/${IMAGE}:5
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${TAG} ${HUB_NAMESPACE}/${IMAGE}:latest
 	$(info Make: Done.)
 endif
 
@@ -50,9 +49,8 @@ endif
 push-alpine-v5:
 ifneq ($(IS_V5),)
 	$(info Make: Pushing tagged images from alpine.)
-	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG}
-	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-5
-	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:${TAG}
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:5
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:latest
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,9 @@ HUB_NAMESPACE="invoiceninja"
 # Image name
 IMAGE="invoiceninja"
 
+# Check if v5 tag is passed, so that a v5 version should be built
+IS_V5=$(shell echo ${TAG} | egrep ^5)
+
 
 # Building docker images based on alpine.
 # Assigned tags:
@@ -15,17 +18,43 @@ IMAGE="invoiceninja"
 #   - :alpine-<RELEASE VERSION>
 .PHONY: build-alpine
 build-alpine:
+ifeq ($(IS_V5),)
 	$(info Make: Building "$(TAG)" tagged images from alpine.)
 	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile .
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine
+	# Tag as alpine-4
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine-4
 	$(info Make: Done.)
+endif
 
 .PHONY: push-alpine
 push-alpine:
+ifeq ($(IS_V5),)
 	$(info Make: Pushing tagged images from alpine.)
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG}
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine
 	$(info Make: Done.)
+endif
+
+.PHONY: build-alpine-v5
+build-alpine-v5:
+ifneq ($(IS_V5),)
+	$(info Make: Building "$(TAG)" tagged images from alpine.)
+	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile_v5 .
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine-5
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:latest
+	$(info Make: Done.)
+endif
+
+.PHONY: push-alpine-v5
+push-alpine-v5:
+ifneq ($(IS_V5),)
+	$(info Make: Pushing tagged images from alpine.)
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG}
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-5
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:latest
+endif
 
 # Building docker images based on debian.
 # Assigned tags:
@@ -33,14 +62,17 @@ push-alpine:
 #   - :<RELEASE VERSION>
 .PHONY: build-debian
 build-debian:
+ifeq ($(IS_V5),)
 	$(info Make: Building "$(TAG)" tagged images from debian.)
 	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./debian/Dockerfile .
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${TAG} ${HUB_NAMESPACE}/${IMAGE}:latest
 	$(info Make: Done.)
+endif
 
 .PHONY: push-debian
 push-debian:
+ifeq ($(IS_V5),)
 	$(info Make: Pushing tagged images from debian.)
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:${TAG}
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:latest
 	$(info Make: Done.)
+endif

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -1,68 +1,87 @@
 ARG PHP_VERSION=7.3
 
+# Get Invoice Ninja
+FROM alpine:latest as base
+ARG INVOICENINJA_VERSION
+
+RUN set -eux; \
+    apk add --no-cache \
+    curl \
+    libarchive-tools; \
+    mkdir -p /var/www/app
+
+RUN curl -o /tmp/ninja.tar.gz -LJ0 https://github.com/invoiceninja/invoiceninja/tarball/v$INVOICENINJA_VERSION \
+    && bsdtar --strip-components=1 -C /var/www/app -xf /tmp/ninja.tar.gz \
+    && rm /tmp/ninja.tar.gz \
+    && cp -R /var/www/app/storage /var/www/app/docker-backup-storage  \
+    && cp -R /var/www/app/public /var/www/app/docker-backup-public  \
+    && mkdir -p /var/www/app/public/logo /var/www/app/storage \
+    && cp /var/www/app/.env.example /var/www/app/.env \
+    && cp /var/www/app/.env.dusk.example /var/www/app/.env.dusk.local \
+    && rm -rf /var/www/app/docs /var/www/app/tests
+
+# Install nodejs packages
+FROM node:12-alpine as frontend
+
+COPY --from=base /var/www/app /var/www/app
+WORKDIR /var/www/app/
+
+RUN npm install
+
+# Prepare php image
 FROM php:${PHP_VERSION}-fpm-alpine
+ARG INVOICENINJA_VERSION
 
 LABEL maintainer="Samuel Laulhau <sam@lalop.co>, Holger Lösken <holger.loesken@codedge.de>"
 
-#####
-# SYSTEM REQUIREMENT
-#####
-ARG INVOICENINJA_VERSION
 WORKDIR /var/www/app
 
+COPY --from=frontend /var/www/app /var/www/app
 COPY ./alpine/entrypoint_v5.sh /usr/local/bin/docker-entrypoint
 RUN chmod +x /usr/local/bin/docker-entrypoint
 
 RUN set -eux; \
     apk add --no-cache \
     gmp-dev \
-    libarchive-tools \
-    libzip-dev
-
-RUN docker-php-ext-configure zip --with-libzip; \
-	docker-php-ext-install -j$(nproc) \
-       bcmath \
-       gmp \
-       mbstring \
-       opcache \
-       pdo \
-       pdo_mysql \
-       zip
+    libzip-dev; \
+    docker-php-ext-configure zip --with-libzip; \
+    docker-php-ext-install -j$(nproc) \
+        bcmath \
+        exif \
+        gmp \
+        mbstring \
+        opcache \
+        pdo \
+        pdo_mysql \
+        zip
 
 COPY ./config/php/php.ini /usr/local/etc/php/php.ini
 COPY ./config/php/php-cli.ini /usr/local/etc/php/php-cli.ini
 
-# Separate user
-ENV IN_USER=invoiceninja
+## Separate user
+ENV INVOICENINJA_USER=invoiceninja
 
-RUN addgroup -S "$IN_USER" && \
+RUN addgroup -S "$INVOICENINJA_USER" && \
     adduser \
     --disabled-password \
     --gecos "" \
     --home "$(pwd)" \
-    --ingroup "$IN_USER" \ 
+    --ingroup "$INVOICENINJA_USER" \ 
     --no-create-home \
-    "$IN_USER"; \
-    addgroup "$IN_USER" www-data; \
-    chown -R "$IN_USER":"$IN_USER" .
+    "$INVOICENINJA_USER"; \
+    addgroup "$INVOICENINJA_USER" www-data; \
+    chown -R "$INVOICENINJA_USER":"$INVOICENINJA_USER" /var/www/app
 
-USER $IN_USER
+# Install Composer
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer; \
+    composer global require hirak/prestissimo;
 
-# Download and install IN
-ENV INVOICENINJA_VERSION="${INVOICENINJA_VERSION}"
+USER $INVOICENINJA_USER
 
-RUN curl -o /tmp/ninja.zip -LJ0 https://github.com/invoiceninja/invoiceninja/tarball/v$INVOICENINJA_VERSION \
-    && bsdtar --strip-components=1 -C /var/www/app -xf /tmp/ninja.zip \
-    && rm /tmp/ninja.zip \
-    && mv /var/www/app/storage /var/www/app/docker-backup-storage  \
-    && mv /var/www/app/public /var/www/app/docker-backup-public  \
-    && mkdir -p /var/www/app/public/logo /var/www/app/storage \
-    && cp /var/www/app/.env.example /var/www/app/.env \
-    && cp .env.dusk.example .env.dusk.local \
-    && chmod -R 755 /var/www/app/storage  \
-    && rm -rf /var/www/app/docs /var/www/app/tests
+RUN composer install --no-dev --no-suggest --no-progress
 
 # Override the environment settings from projects .env file
+ENV APP_ENV production
 ENV LOG errorlog
 
 # Use to be mounted into nginx

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -1,0 +1,72 @@
+ARG PHP_VERSION=7.3
+
+FROM php:${PHP_VERSION}-fpm-alpine
+
+LABEL maintainer="Samuel Laulhau <sam@lalop.co>, Holger Lösken <holger.loesken@codedge.de>"
+
+#####
+# SYSTEM REQUIREMENT
+#####
+ARG INVOICENINJA_VERSION
+WORKDIR /var/www/app
+
+COPY ./alpine/entrypoint_v5.sh /usr/local/bin/docker-entrypoint
+RUN chmod +x /usr/local/bin/docker-entrypoint
+
+RUN set -eux; \
+    apk add --no-cache \
+    gmp-dev \
+    libarchive-tools \
+    libzip-dev
+
+RUN docker-php-ext-configure zip --with-libzip; \
+	docker-php-ext-install -j$(nproc) \
+       bcmath \
+       gmp \
+       mbstring \
+       opcache \
+       pdo \
+       pdo_mysql \
+       zip
+
+COPY ./config/php/php.ini /usr/local/etc/php/php.ini
+COPY ./config/php/php-cli.ini /usr/local/etc/php/php-cli.ini
+
+# Separate user
+ENV IN_USER=invoiceninja
+
+RUN addgroup -S "$IN_USER" && \
+    adduser \
+    --disabled-password \
+    --gecos "" \
+    --home "$(pwd)" \
+    --ingroup "$IN_USER" \ 
+    --no-create-home \
+    "$IN_USER"; \
+    addgroup "$IN_USER" www-data; \
+    chown -R "$IN_USER":"$IN_USER" .
+
+USER $IN_USER
+
+# Download and install IN
+ENV INVOICENINJA_VERSION="${INVOICENINJA_VERSION}"
+
+RUN curl -o /tmp/ninja.zip -LJ0 https://github.com/invoiceninja/invoiceninja/tarball/v$INVOICENINJA_VERSION \
+    && bsdtar --strip-components=1 -C /var/www/app -xf /tmp/ninja.zip \
+    && rm /tmp/ninja.zip \
+    && mv /var/www/app/storage /var/www/app/docker-backup-storage  \
+    && mv /var/www/app/public /var/www/app/docker-backup-public  \
+    && mkdir -p /var/www/app/public/logo /var/www/app/storage \
+    && cp /var/www/app/.env.example /var/www/app/.env \
+    && cp .env.dusk.example .env.dusk.local \
+    && chmod -R 755 /var/www/app/storage  \
+    && rm -rf /var/www/app/docs /var/www/app/tests
+
+# Override the environment settings from projects .env file
+ENV LOG errorlog
+
+# Use to be mounted into nginx
+VOLUME /var/www/app/public
+
+ENTRYPOINT ["docker-entrypoint"]
+CMD ["php-fpm"]

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -42,14 +42,20 @@ RUN chmod +x /usr/local/bin/docker-entrypoint
 
 RUN set -eux; \
     apk add --no-cache \
+    freetype-dev \
     gmp-dev \
+    libjpeg-turbo-dev \
+    libpng-dev \
     libzip-dev; \
     docker-php-ext-configure zip --with-libzip; \
+    docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ --with-png-dir=/usr/include/; \
     docker-php-ext-install -j$(nproc) \
         bcmath \
         exif \
+        gd \
         gmp \
         mbstring \
+        mysqli \
         opcache \
         pdo \
         pdo_mysql \

--- a/alpine/entrypoint_v5.sh
+++ b/alpine/entrypoint_v5.sh
@@ -45,10 +45,6 @@ fi
 chown invoiceninja:www-data /var/www/app/storage
 chown invoiceninja:www-data /var/www/app/public
 
-# Database migrations and seeding
-php artisan migrate --force
-php artisan db:seed --force
-
 php artisan optimize
 
 exec docker-php-entrypoint "$@"

--- a/alpine/entrypoint_v5.sh
+++ b/alpine/entrypoint_v5.sh
@@ -12,7 +12,7 @@ BAK_LOGO_PATH=/var/www/app/docker-backup-public/logo/
 if [ ! -d /var/www/app/storage ]; then
     cp -Rp $BAK_STORAGE_PATH /var/www/app/storage
 else
-    if [ -d $BAK_STORAGE_PATH]; then
+    if [ -d $BAK_STORAGE_PATH ]; then
         IN_STORAGE_BACKUP="$(ls $BAK_STORAGE_PATH)"
         for path in $IN_STORAGE_BACKUP; do
             if [ ! -e "/var/www/app/storage/$path" ]; then
@@ -44,5 +44,11 @@ fi
 # Set permission for mounted directories
 chown invoiceninja:www-data /var/www/app/storage
 chown invoiceninja:www-data /var/www/app/public
+
+# Database migrations and seeding
+php artisan migrate --force
+php artisan db:seed --force
+
+php artisan optimize
 
 exec docker-php-entrypoint "$@"

--- a/alpine/entrypoint_v5.sh
+++ b/alpine/entrypoint_v5.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -e
+
+# first arg is `-f` or `--some-option`
+if [ "${1#-}" != "$1" ]; then
+	set -- php-fpm "$@"
+fi
+
+BAK_STORAGE_PATH=/var/www/app/docker-backup-storage/
+BAK_LOGO_PATH=/var/www/app/docker-backup-public/logo/
+
+if [ ! -d /var/www/app/storage ]; then
+    cp -Rp $BAK_STORAGE_PATH /var/www/app/storage
+else
+    if [ -d $BAK_STORAGE_PATH]; then
+        IN_STORAGE_BACKUP="$(ls $BAK_STORAGE_PATH)"
+        for path in $IN_STORAGE_BACKUP; do
+            if [ ! -e "/var/www/app/storage/$path" ]; then
+                cp -Rp "$BAK_STORAGE_PATH/$path" "/var/www/app/storage/"
+            fi
+        done
+    fi
+fi
+
+if [ ! -d /var/www/app/public/logo ] && [ -d $BAK_LOGO_PATH ]; then
+    cp -Rp $BAK_LOGO_PATH /var/www/app/public/logo
+else
+    if [ -d $BAK_LOGO_PATH ]; then
+        IN_LOGO_BACKUP="$(ls $BAK_LOGO_PATH)"
+        for path in $IN_LOGO_BACKUP; do
+            if [ ! -e "/var/www/app/public/logo/$path" ]; then
+                cp -Rp "$BAK_LOGO_PATH/$path" "/var/www/app/public/logo/"
+            fi
+        done
+    fi
+fi
+
+# compare public volume version with image version
+if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
+    cp -au /var/www/app/docker-backup-public/* /var/www/app/public/
+    echo $INVOICENINJA_VERSION > /var/www/app/public/version
+fi
+
+# Set permission for mounted directories
+chown invoiceninja:www-data /var/www/app/storage
+chown invoiceninja:www-data /var/www/app/public
+
+exec docker-php-entrypoint "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,12 +28,15 @@ services:
       - invoiceninja
 
   app:
-    image: invoiceninja/invoiceninja:alpine
+    image: invoiceninja/invoiceninja:5
     restart: always
     environment: 
       - APP_URL=https://localhost
       - APP_KEY=<INSERT THE GENERATED APPLICATION KEY HERE>
       - DB_HOST=db
+      - MULTI_DB_ENABLED=false
+      - DB_HOST1=db
+      - DB_DATABASE1=ninja
     volumes:
       # Configure your mounted directories, make sure the folder 'public' and 'storage'
       # exist, before mounting them

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,6 @@ services:
     environment: 
       - APP_URL=https://localhost
       - APP_KEY=<INSERT THE GENERATED APPLICATION KEY HERE>
-      - DB_HOST=db
       - MULTI_DB_ENABLED=false
       - DB_HOST1=db
       - DB_DATABASE1=ninja


### PR DESCRIPTION
Closes #136.

This PR build docker images for both, v1 (4.x) and v2 (5.x), versions of IN.

## Tags
* **`latest`**: latest 5.x version based on Alpine
* `5.x`: specific 5.x version based on Alpine
* `5`: latest 5.x version based on Alpine

### Old tags
* `4.x`: specific 4.x version based on Debian (deprecated)
* `alpine`: latest 4.x version based on Alpine
* `alpine-4`: latest 4.x version based on Alpine
* `alpine-4.x`: specific v4 version based on Alpine

There won't be any v5 version based on any other base image than Alpine.