### PR TITLE
Extracting version out of tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ IMAGE="invoiceninja"
 # Check if v5 tag is passed, so that a v5 version should be built
 IS_V5=$(shell echo ${TAG} | egrep ^5)
 
+# Version of Invoice Ninja. As the tag can be something like 5.0.4-p1, the version is 5.0.4.
+# This supports changes to the Dockerfiles with always the same Invoice Ninja version
+VERSION=$(shell echo ${TAG} | sed "s/-.*//")
 
 # Building docker images based on alpine.
 # Assigned tags:
@@ -19,10 +22,10 @@ IS_V5=$(shell echo ${TAG} | egrep ^5)
 .PHONY: build-alpine
 build-alpine:
 ifeq ($(IS_V5),)
-	$(info Make: Building "$(TAG)" tagged images from alpine.)
-	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile .
+	$(info Make: Building "$(VERSION)" tagged images from alpine.)
+	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:alpine-${VERSION} --build-arg INVOICENINJA_VERSION=${VERSION} --file ./alpine/Dockerfile .
 	# Tag as alpine-4
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG} ${HUB_NAMESPACE}/${IMAGE}:alpine-4
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:alpine-${VERSION} ${HUB_NAMESPACE}/${IMAGE}:alpine-4
 	$(info Make: Done.)
 endif
 
@@ -30,7 +33,7 @@ endif
 push-alpine:
 ifeq ($(IS_V5),)
 	$(info Make: Pushing tagged images from alpine.)
-	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-${TAG}
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-${VERSION}
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:alpine-4
 	$(info Make: Done.)
 endif
@@ -38,10 +41,10 @@ endif
 .PHONY: build-alpine-v5
 build-alpine-v5:
 ifneq ($(IS_V5),)
-	$(info Make: Building "$(TAG)" tagged images from alpine.)
-	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:${TAG} --build-arg INVOICENINJA_VERSION=${TAG} --file ./alpine/Dockerfile_v5 .
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${TAG} ${HUB_NAMESPACE}/${IMAGE}:5
-	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${TAG} ${HUB_NAMESPACE}/${IMAGE}:latest
+	$(info Make: Building "$(VERSION)" tagged images from alpine.)
+	@docker build -t ${HUB_NAMESPACE}/${IMAGE}:${VERSION} --build-arg INVOICENINJA_VERSION=${VERSION} --file ./alpine/Dockerfile_v5 .
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${VERSION} ${HUB_NAMESPACE}/${IMAGE}:5
+	@docker tag ${HUB_NAMESPACE}/${IMAGE}:${VERSION} ${HUB_NAMESPACE}/${IMAGE}:latest
 	$(info Make: Done.)
 endif
 
@@ -49,7 +52,7 @@ endif
 push-alpine-v5:
 ifneq ($(IS_V5),)
 	$(info Make: Pushing tagged images from alpine.)
-	@docker push ${HUB_NAMESPACE}/${IMAGE}:${TAG}
+	@docker push ${HUB_NAMESPACE}/${IMAGE}:${VERSION}
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:5
 	@docker push ${HUB_NAMESPACE}/${IMAGE}:latest
 endif


### PR DESCRIPTION
This PR makes it possible to update the Dockerfiles without increasing the version of IN.

**Use case**

Create a new release/tag `5.0.4` will built the image for IN 5.0.4.
Now, when something is wrong or needs to be fixed with the Dockerfiles, entrypoint, etc. we delete the release/tag and create it again to deploy changes to the docker setup.

But now you can just create a new release `5.0.4-p1` which will built the new images, with IN `5.0.4` but also with the changes made to the docker setup. 

So we suffix the IN version with `-pX`. And we do not need to delete and recreate releases here.