### PR TITLE
Minor fix for docker composer

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
       - MYSQL_ROOT_PASSWORD=ninjaAdm1nPassword
       - MYSQL_USER=ninja
       - MYSQL_PASSWORD=ninja
-      - MYSQL_DATABASE=db-ninja-01
+      - MYSQL_DATABASE=ninja
     volumes:
       - mysql-data:/var/lib/mysql:rw
       # you may use a bind-mounted host directory instead, so that it is harder to accidentally remove the volume and lose all your data!


### PR DESCRIPTION
One small thing noticed is that the default db_name of db-ninja-01 doesn't seem to work, however replacing with ninja sees a smooth install.

Unsure of the root cause, but feel using ninja may be a better experience for users?