### PR TITLE
(v5) Add environment variable to skip downloading Chromium (snappdf)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - DB_DATABASE1=ninja
       - PHANTOMJS_PDF_GENERATION=false
       - SNAPPDF_EXECUTABLE_PATH="/usr/bin/chromium-browser"
+      - SNAPPDF_SKIP_DOWNLOAD=true
     volumes:
       # Configure your mounted directories, make sure the folder 'public' and 'storage'
       # exist, before mounting them


### PR DESCRIPTION
In Docker, we install chromium-browser separately. This will make sure we don't download & duplicate chromium versions.

https://github.com/beganovich/snappdf#skip-the-chromium-download