### PR TITLE
Enhancement and Fixes for Dockerfile

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,4 +1,6 @@
 ARG PHP_VERSION=7.2
+ARG BAK_STORAGE_PATH=/var/www/app/docker-backup-storage/
+ARG BAK_PUBLIC_PATH=/var/www/app/docker-backup-public/
 
 FROM php:${PHP_VERSION}-fpm-alpine
 
@@ -8,6 +10,10 @@ LABEL maintainer="David Bomba <turbo124@gmail.com>"
 # SYSTEM REQUIREMENT
 #####
 ARG INVOICENINJA_VERSION
+ARG BAK_STORAGE_PATH
+ARG BAK_PUBLIC_PATH
+ENV BAK_STORAGE_PATH $BAK_STORAGE_PATH
+ENV BAK_PUBLIC_PATH $BAK_PUBLIC_PATH
 WORKDIR /var/www/app
 
 COPY entrypoint.sh /usr/local/bin/docker-entrypoint
@@ -60,8 +66,8 @@ ENV INVOICENINJA_VERSION="${INVOICENINJA_VERSION}"
 RUN curl -s -o /tmp/ninja.zip -SL https://download.invoiceninja.com/ninja-v${INVOICENINJA_VERSION}.zip \
     && bsdtar --strip-components=1 -C /var/www/app -xf /tmp/ninja.zip \
     && rm /tmp/ninja.zip \
-    && mv /var/www/app/storage /var/www/app/docker-backup-storage  \
-    && mv /var/www/app/public /var/www/app/docker-backup-public  \
+    && mv /var/www/app/storage $BAK_STORAGE_PATH  \
+    && mv /var/www/app/public $BAK_PUBLIC_PATH  \
     && mkdir -p /var/www/app/public/logo /var/www/app/storage \
     && chmod -R 755 /var/www/app/storage  \
     && rm -rf /var/www/app/docs /var/www/app/tests

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -45,20 +45,20 @@ COPY ./config/php/php.ini /usr/local/etc/php/php.ini
 COPY ./config/php/php-cli.ini /usr/local/etc/php/php-cli.ini
 
 # Separate user
-ENV IN_USER=invoiceninja
+ENV INVOICENINJA_USER=invoiceninja
 
-RUN addgroup --gid=1500 -S "$IN_USER" && \
+RUN addgroup --gid=1500 -S "$INVOICENINJA_USER" && \
     adduser --uid=1500 \
     --disabled-password \
     --gecos "" \
     --home "$(pwd)" \
-    --ingroup "$IN_USER" \ 
+    --ingroup "$INVOICENINJA_USER" \ 
     --no-create-home \
-    "$IN_USER"; \
-    addgroup "$IN_USER" www-data; \
-    chown -R "$IN_USER":"$IN_USER" .
+    "$INVOICENINJA_USER"; \
+    addgroup "$INVOICENINJA_USER" www-data; \
+    chown -R "$INVOICENINJA_USER":"$INVOICENINJA_USER" .
 
-USER $IN_USER
+USER $INVOICENINJA_USER
 
 # Download and install IN
 ENV INVOICENINJA_VERSION="${INVOICENINJA_VERSION}"

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -1,37 +1,35 @@
 ARG PHP_VERSION=7.4
 
-# Get Invoice Ninja
-FROM alpine:latest as base
+# Get Invoice Ninja and install nodejs packages
+FROM node:lts-alpine as frontend
 ARG INVOICENINJA_VERSION
 
+# Install dependencies
 RUN set -eux; \
     apk add --no-cache \
     curl
 
+# Download Invoice Ninja
 RUN curl -o /tmp/ninja.tar.gz -LJ0 https://github.com/invoiceninja/invoiceninja/tarball/v$INVOICENINJA_VERSION \
     && mkdir -p /var/www/app \
     && tar --strip-components=1 -xf /tmp/ninja.tar.gz -C /var/www/app/ \
-    && rm /tmp/ninja.tar.gz \
-    && cp -R /var/www/app/storage /var/www/app/docker-backup-storage  \
-    && cp -R /var/www/app/public /var/www/app/docker-backup-public  \
     && mkdir -p /var/www/app/public/logo /var/www/app/storage \
-    && cp /var/www/app/.env.example /var/www/app/.env \
+    && mv /var/www/app/.env.example /var/www/app/.env \
     && rm -rf /var/www/app/docs /var/www/app/tests
 
-# Install nodejs packages
-FROM node:12-alpine as frontend
-
-COPY --from=base /var/www/app /var/www/app
 WORKDIR /var/www/app/
 
+# Install node packages
 RUN npm install --production \
     && npm run production \
-    && rm -rf node_modules
+    && rm -rf node_modules \
+    && mv /var/www/app/storage /var/www/app/docker-backup-storage/ \
+    && mv /var/www/app/public /var/www/app/docker-backup-public/
 
 # Prepare php image
 FROM php:${PHP_VERSION}-fpm-alpine
 ARG INVOICENINJA_VERSION
-ENV INVOICENINJA_VERSION=$INVOICENINJA_VERSION
+ENV INVOICENINJA_VERSION $INVOICENINJA_VERSION
 
 LABEL maintainer="David Bomba <turbo124@gmail.com>"
 
@@ -49,9 +47,9 @@ RUN set -eux; \
     libjpeg-turbo-dev \
     libpng-dev \
     libzip-dev \
-    oniguruma-dev \
-    git \
-    busybox-suid \
+    # oniguruma-dev \
+    # git \
+    # busybox-suid \
     zip \
     chromium \
     harfbuzz \
@@ -62,10 +60,8 @@ RUN set -eux; \
         exif \
         gd \
         gmp \
-#        mbstring \
         mysqli \
         opcache \
-        pdo \
         pdo_mysql \
         zip
 
@@ -92,7 +88,7 @@ RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local
 
 USER $INVOICENINJA_USER
 
-RUN /usr/local/bin/composer install --no-dev --no-suggest --no-progress --quiet
+RUN /usr/local/bin/composer install --no-dev --quiet
 
 # Override the environment settings from projects .env file
 ENV APP_ENV production

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -77,10 +77,11 @@ COPY ./config/php/php.ini /usr/local/etc/php/php.ini
 COPY ./config/php/php-cli.ini /usr/local/etc/php/php-cli.ini
 
 ## Separate user
+ARG UID=1500
 ENV INVOICENINJA_USER=invoiceninja
 
-RUN addgroup --gid=1500 -S "$INVOICENINJA_USER" \
-    && adduser --uid=1500 \
+RUN addgroup --gid=$UID -S "$INVOICENINJA_USER" \
+    && adduser --uid=$UID \
     --disabled-password \
     --gecos "" \
     --home "$(pwd)" \
@@ -94,7 +95,7 @@ RUN addgroup --gid=1500 -S "$INVOICENINJA_USER" \
 # Install Composer
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer; 
 
-USER $INVOICENINJA_USER
+USER $UID
 
 RUN /usr/local/bin/composer install --no-dev --quiet
 

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -1,8 +1,12 @@
 ARG PHP_VERSION=7.4
+ARG BAK_STORAGE_PATH=/var/www/app/docker-backup-storage/
+ARG BAK_PUBLIC_PATH=/var/www/app/docker-backup-public/
 
 # Get Invoice Ninja and install nodejs packages
 FROM node:lts-alpine as frontend
 ARG INVOICENINJA_VERSION
+ARG BAK_STORAGE_PATH
+ARG BAK_PUBLIC_PATH
 
 # Install dependencies
 RUN set -eux; \
@@ -23,13 +27,17 @@ WORKDIR /var/www/app/
 RUN npm install --production \
     && npm run production \
     && rm -rf node_modules \
-    && mv /var/www/app/storage /var/www/app/docker-backup-storage/ \
-    && mv /var/www/app/public /var/www/app/docker-backup-public/
+    && mv /var/www/app/storage $BAK_STORAGE_PATH \
+    && mv /var/www/app/public $BAK_PUBLIC_PATH
 
 # Prepare php image
 FROM php:${PHP_VERSION}-fpm-alpine
 ARG INVOICENINJA_VERSION
+ARG BAK_STORAGE_PATH
+ARG BAK_PUBLIC_PATH
 ENV INVOICENINJA_VERSION $INVOICENINJA_VERSION
+ENV BAK_STORAGE_PATH $BAK_STORAGE_PATH
+ENV BAK_PUBLIC_PATH $BAK_PUBLIC_PATH
 
 LABEL maintainer="David Bomba <turbo124@gmail.com>"
 

--- a/alpine/Dockerfile_v5
+++ b/alpine/Dockerfile_v5
@@ -56,7 +56,7 @@ RUN set -eux; \
     libpng-dev \
     libzip-dev \
     # oniguruma-dev \
-    # git \
+    git \
     # busybox-suid \
     zip \
     chromium \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,7 +70,9 @@ services:
       - ./docker/app/public:/var/www/app/public:rw,delegated
       - ./docker/app/storage:/var/www/app/storage:rw,delegated
     command:
-    - cron.sh
+      - cron.sh
+    depends_on:
+      - app
     networks:
       - invoiceninja
     extra_hosts:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -83,7 +83,7 @@ fi
 rm -rf "$BAK_PUBLIC_PATH"
 
 # Set permission for web server to create/update files
-chown -R invoiceninja:www-data /var/www/app/storage /var/www/app/public /var/www/app/bootstrap
+chown -R "$INVOICENINJA_USER":www-data /var/www/app/storage /var/www/app/public /var/www/app/bootstrap
 
 # Initialize values that might be stored in a file
 file_env 'APP_KEY'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,40 +47,37 @@ if [ "${1#-}" != "$1" ]; then
 	set -- php-fpm "$@"
 fi
 
-BAK_STORAGE_PATH=/var/www/app/docker-backup-storage/
-BAK_LOGO_PATH=/var/www/app/docker-backup-public/logo/
-
-if [ ! -d /var/www/app/storage ]; then
-    cp -Rp $BAK_STORAGE_PATH /var/www/app/storage
-else
-    if [ -d $BAK_STORAGE_PATH ]; then
-        IN_STORAGE_BACKUP="$(ls $BAK_STORAGE_PATH)"
-        for path in $IN_STORAGE_BACKUP; do
-            if [ ! -e "/var/www/app/storage/$path" ]; then
-                cp -Rp "$BAK_STORAGE_PATH/$path" "/var/www/app/storage/"
-            fi
-        done
-    fi
+# create storage volume
+if [ ! -d /var/www/app/storage ] && [ -d "$BAK_STORAGE_PATH" ]; then
+    mv "$BAK_STORAGE_PATH" /var/www/app/storage
+elif [ -d "$BAK_STORAGE_PATH" ]; then
+    IN_STORAGE_BACKUP="$(ls "$BAK_STORAGE_PATH")"
+    for path in $IN_STORAGE_BACKUP; do
+        if [ ! -e "/var/www/app/storage/$path" ]; then
+            cp -Rp "$BAK_STORAGE_PATH/$path" "/var/www/app/storage/"
+        fi
+    done
 fi
+rm -rf "$BAK_STORAGE_PATH"
 
-if [ ! -d /var/www/app/public/logo ] && [ -d $BAK_LOGO_PATH ]; then
-    cp -Rp $BAK_LOGO_PATH /var/www/app/public/logo
-else
-    if [ -d $BAK_LOGO_PATH ]; then
-        IN_LOGO_BACKUP="$(ls $BAK_LOGO_PATH)"
-        for path in $IN_LOGO_BACKUP; do
-            if [ ! -e "/var/www/app/public/logo/$path" ]; then
-                cp -Rp "$BAK_LOGO_PATH/$path" "/var/www/app/public/logo/"
-            fi
-        done
-    fi
-fi
-
-# compare public volume version with image version
+# create public volume
 if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
-    cp -au /var/www/app/docker-backup-public/* /var/www/app/public/
-    echo $INVOICENINJA_VERSION > /var/www/app/public/version
+    # version mismatch, update all
+    cp -au "$BAK_PUBLIC_PATH/"* /var/www/app/public
+    echo "$INVOICENINJA_VERSION" > /var/www/app/public/version
+elif [ ! -d /var/www/app/public/logo ] && [ -d "$BAK_PUBLIC_PATH/logo" ]; then
+    # missing logo folder only, copy folder
+    cp -a "$BAK_PUBLIC_PATH/logo" /var/www/app/public/logo
+elif [ -d "$BAK_PUBLIC_PATH/logo" ]; then
+    # update logo folder anyways
+    IN_LOGO_BACKUP="$(ls "$BAK_PUBLIC_PATH/logo")"
+    for path in $IN_LOGO_BACKUP; do
+        if [ ! -e "/var/www/app/public/logo/$path" ]; then
+            cp -a "$BAK_PUBLIC_PATH/logo/$path" "/var/www/app/public/logo/"
+        fi
+    done
 fi
+rm -rf "$BAK_PUBLIC_PATH"
 
 # Set permission for web server to create/update files
 chown -R invoiceninja:www-data /var/www/app/storage /var/www/app/public /var/www/app/bootstrap

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -51,6 +51,7 @@ fi
 if [ ! -d /var/www/app/storage ] && [ -d "$BAK_STORAGE_PATH" ]; then
     mv "$BAK_STORAGE_PATH" /var/www/app/storage
 elif [ -d "$BAK_STORAGE_PATH" ]; then
+    # copy missing folders in storage
     IN_STORAGE_BACKUP="$(ls "$BAK_STORAGE_PATH")"
     for path in $IN_STORAGE_BACKUP; do
         if [ ! -e "/var/www/app/storage/$path" ]; then
@@ -61,7 +62,9 @@ fi
 rm -rf "$BAK_STORAGE_PATH"
 
 # create public volume
-if [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
+if [ ! -d /var/www/app/public ] && [ -d "$BAK_PUBLIC_PATH" ]; then
+    mv "$BAK_PUBLIC_PATH" /var/www/app/public
+elif [ ! -e /var/www/app/public/version ] || [ "$INVOICENINJA_VERSION" != "$(cat /var/www/app/public/version)" ]; then
     # version mismatch, update all
     cp -au "$BAK_PUBLIC_PATH/"* /var/www/app/public
     echo "$INVOICENINJA_VERSION" > /var/www/app/public/version
@@ -69,7 +72,7 @@ elif [ ! -d /var/www/app/public/logo ] && [ -d "$BAK_PUBLIC_PATH/logo" ]; then
     # missing logo folder only, copy folder
     cp -a "$BAK_PUBLIC_PATH/logo" /var/www/app/public/logo
 elif [ -d "$BAK_PUBLIC_PATH/logo" ]; then
-    # update logo folder anyways
+    # copy missing folders in logo
     IN_LOGO_BACKUP="$(ls "$BAK_PUBLIC_PATH/logo")"
     for path in $IN_LOGO_BACKUP; do
         if [ ! -e "/var/www/app/public/logo/$path" ]; then


### PR DESCRIPTION
Hi,

I've made multiple updates, and have split them up into multiple commits for easier review.

1. Update cron to depend on app 
   - This prevents both the cron and app to concurrently copy files from BAK + migration, *IF* heath check is set up

2. Move BAK after npm run prod
   - A mounted volume will not be updated if files are copied from `public` to `BAK_PUBLIC_PATH` before npm run prod is ran
   - remove PDO extension as it comes with fpm
   - Please help to check if the following three lines are legacy, IN works well without them
```
      # oniguruma-dev \
      # git \
      # busybox-suid \
```
   
3. Update Dockerfiles to use ENV for BAK paths
   - Allow updating of BAK paths using ARG
   - Export ARG to ENV

4. Update entrypoint.sh to use ENV paths + cleanup
   - Use BAK paths from ENV
   - streamline if else statements
   - replace some `cp -Rp` with `cp -a`, to reduce copying during `cp -au` when updated

5. Use uid for `USER` to allow running in k8s with non-root PSP
   - using `USER <name>` prevents running on a harden k8s cluster

The last 2 commits should be straightforward.
Please let me know if you have any concerns. Hope it helps!
