### PR TITLE
Rescope build_push.yaml

### DIFF
--- a/.github/workflows/build_push.yml
+++ b/.github/workflows/build_push.yml
@@ -1,8 +1,9 @@
 name: Docker images
 
 on:
-  release:
-    types: [published]
+  push:
+    tags-ignore:
+      - "invoiceninja-*"
 
 jobs:
   deploy:
@@ -11,10 +12,10 @@ jobs:
 
     steps:
         - uses: actions/checkout@v1
-        
+
         - name: Login to DockerHub
           run: echo ${{ secrets.DOCKERHUB_PASSWORD }} | docker login -u ${{ secrets.DOCKERHUB_USERNAME }} --password-stdin
-        
+
         - name: Get the latest tag
           id: vars
           run: echo ::set-output name=tag::$(echo ${GITHUB_REF:10})


### PR DESCRIPTION
The helm chart release action `release.yml` will create and publish releases and tags with the prefix "invoiceninja-<helm-chart-version>" once you merge it to master.

That will cause the current `build_push.yml` to be triggered. By amending it as such, `build_push.yml` will only be triggered by creating a release with a tag other than "invoiceninja-*". Will work with your current release workflow that is tagged e.g. 4.x.x, 5.x.x, ...

Let me know if this is okay with you?

I'll text you over slack for the first chart release. 