### PR TITLE
Added MariaDB to Docker compose for ARM64

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Docker image, latest](https://img.shields.io/docker/image-size/invoiceninja/invoiceninja/latest?label=latest)](https://hub.docker.com/r/invoiceninja/invoiceninja)
 [![Docker image, alpine](https://img.shields.io/docker/image-size/invoiceninja/invoiceninja/alpine?label=alpine)](https://hub.docker.com/r/invoiceninja/invoiceninja)
 
-# Docker for [Invoice Ninja](https://www.invoiceninja.com/) 
+# Docker for [Invoice Ninja](https://www.invoiceninja.com/)
 
 :crown: **Features**
 
@@ -13,11 +13,11 @@
 
 ## You want some Kubernetes + Helm with that?
 [Helm Chat](https://github.com/Saddamus/invoiceninja-helm) by @Saddamus  
-[Kubernetes](https://github.com/invoiceninja/dockerfiles/issues/94) by @spacepluk 
+[Kubernetes](https://github.com/invoiceninja/dockerfiles/issues/94) by @spacepluk
 
 ## Quickstart V5 Launch
 
-The dockerfile has been revamped to make is easier to get started, by default the base image selected in 5 which will pull in the latest v5 stable image.
+The dockerfile has been revamped to make it easier to get started, by default the base image selected is 5 which will pull in the latest v5 stable image.
 
 ```bash
 git clone https://github.com/invoiceninja/dockerfiles.git
@@ -65,7 +65,7 @@ For example, lets say your APP_URL is ```http://in5.test:8000``` and your LAN IP
 
 ```192.168.0.124 in5.test```
 
-**Please note that PDF generation using local host your domain name MUST end in .test for your PDFs to generate correctly, this is a DNS resolver issue with chromium.
+**Please note that for PDF generation using local host, your domain name MUST end in .test for your PDFs to generate correctly, this is a DNS resolver issue with chromium.
 
 All that is left to do now is bring up the container
 
@@ -75,9 +75,13 @@ All that is left to do now is bring up the container
 
 **Note: When performing the setup, the Database host is ```db```
 
+### Running on ARM64 (Raspberry Pi 4)
+
+When deploying on an ARM64 system, you need to comment out the `image: mysql:5` line and uncomment `image: mariadb:10.4` in the `docker-compose.yml` file.
+
 ## Updating the Image when using `docker-compose`
 
-As `docker-compose` does not support any form of version control, this git provide updates to `docker-compose.yml` directly. 
+As `docker-compose` does not support any form of version control, this git provide updates to `docker-compose.yml` directly.
 
 To upgrade to a newer release image, please make sure to update the `docker-compose.yml` first by running
 

--- a/config/mysql/Dockerfile
+++ b/config/mysql/Dockerfile
@@ -1,4 +1,6 @@
 FROM mysql:5
+# When running on ARM64 use MariaDB instead of MySQL
+#FROM mariadb:10.4
 ENV force_color_prompt yes
 
 RUN apt-get update;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - app
     # Run webserver nginx on port 80
     # Feel free to modify depending what port is already occupied
-    ports: 
+    ports:
       - "80:80"
       #- "443:443"
     networks:
@@ -32,20 +32,22 @@ services:
       - ./docker/app/storage:/var/www/app/storage:rw,delegated
     depends_on:
       - db
-    networks: 
-      - invoiceninja  
+    networks:
+      - invoiceninja
     extra_hosts:
       - "in5.localhost:192.168.0.124 " #host and ip
 
   db:
     image: mysql:5
+#    When running on ARM64 use MariaDB instead of MySQL
+#    image: mariadb:10.4
 #    For auto DB backups comment out image and use the build block below
 #    build:
 #      context: ./config/mysql
     ports:
       - "3305:3306"
     restart: always
-    environment: 
+    environment:
       - MYSQL_ROOT_PASSWORD=ninjaAdm1nPassword
       - MYSQL_USER=ninja
       - MYSQL_PASSWORD=ninja
@@ -82,7 +84,7 @@ services:
   #     EOF'
   #   networks:
   #     - invoiceninja
-  #     
+  #
 
 networks:
   invoiceninja:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,11 +47,7 @@ services:
     ports:
       - "3305:3306"
     restart: always
-    environment:
-      - MYSQL_ROOT_PASSWORD=ninjaAdm1nPassword
-      - MYSQL_USER=ninja
-      - MYSQL_PASSWORD=ninja
-      - MYSQL_DATABASE=ninja
+    env_file: env
     volumes:
       - ./docker/mysql/data:/var/lib/mysql:rw,delegated
 

--- a/env
+++ b/env
@@ -7,6 +7,10 @@ DB_PORT1=3306
 DB_USERNAME1=ninja
 DB_PASSWORD1=ninja
 DB_DATABASE1=ninja
+MYSQL_ROOT_PASSWORD=ninjaAdm1nPassword
+MYSQL_USER=ninja
+MYSQL_PASSWORD=ninja
+MYSQL_DATABASE=ninja
 
 #this is a system variable please do not remove
 IS_DOCKER=true


### PR DESCRIPTION
Hello, following the suggestion made by @turbo124 in the [discussion](https://github.com/invoiceninja/dockerfiles/pull/307#issuecomment-810126351) regarding commit #307, I've created this PR which brings the following modifications:

#### General remark

My IDE (Atom) is configured to use the included `.editorconfig` file. Nevertheless it seems that the files I edited got modified lines which I didn't touch because:
 - trailing spaces were suppressed at the end of some lines
 - a newline was added at the end of the edited files

Consequently `diff` displays those modifications, making it less clear what lines were intentionally changed. 

#### MariaDB instead of MySQL on ARM64 (adae9a0)

Commented out lines in the `docker-compose.yml` file were added to suggests using `image: mariadb:10.4` instead of `image: mysql:5` when running on ARM64. This was tested and is working on a Raspberry Pi 4.

The same was added to the `config/mysql/Dockerfile` but wasn't tested yet, although I can't see a reason why it wouldn't behave as correctly as it does in the standard deployment.

The `README.md` file was also updated to include a hint on the change required for ARM64 architecture compatibility.\
(Also really minor corrections were made in the existing text 😉)

#### MYSQL environment variables moved to the `env` file (acdb708)

Since it is stated in the README that:
> Instead of defining our environment variables inside our docker-compose.yml file we now define this in the env file

It seemed logical to also move the `MYSQL_` related environment values to this `env` file, hope you will agree with this move.

#### Final remark: first launch database failure

What I could notice is that when **deploying for the very first time using `docker-compose up -d` a database failure is reported**:
> SQLSTATE[42S02]: Base table or view not found: 1146 Table 'ninja.accounts' doesn't exist (SQL: select * from `accounts` limit 1)

I could notice that, although the `docker/mysql/data/ninja/` and all other mysql related files get created, **the invoiceninja related database doesn't appear**.

Stopping the containers (`docker-compose down`) and restarting them (`docker-compose up -d`) fixes the problem as, this time, all invoiceninja related tables are correctly created. I haven't had the time to dig into this, and to be honest I don't even know where to start with that problem. I have the feeling this might be a timing problem, since during the very first run mysql has to initiate it's own file structures and databases, so it might be that the initial migration command from invoiceninja cannot execute because mysql itself isn't ready yet?

I simply wanted to let you know about this situation and maybe would it be adequate to create an issue about this in the repo?