### PR TITLE
Version 3 needed for Pi 4 ARM64

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,4 @@
+#version: '3' #Uncomment if Raspberry Pi 4 ARM64
 version: '3.7'
 
 services:


### PR DESCRIPTION
pi@raspberrypi:~/dockerfiles $ sudo docker-compose up -d
ERROR: Version in "./docker-compose.yml" is unsupported. You might be seeing this error because you're using the wrong Compose file version. Either specify a supported version (e.g "2.2" or "3.3") and place your service definitions under the `services` key, or omit the `version` key and place your service definitions at the root of the file to use version 1.
For more on the Compose file format versions, see https://docs.docker.com/compose/compose-file/

Changing to Version 3 removes this error and it starts the Containers error free