### PR TITLE
Set FastCGI HTTPS Param

### DIFF
--- a/config/nginx/in-vhost.conf
+++ b/config/nginx/in-vhost.conf
@@ -23,5 +23,6 @@ server {
         fastcgi_intercept_errors off;
         fastcgi_buffer_size 16k;
         fastcgi_buffers 4 16k;
+        fastcgi_param HTTPS $https;
     }
 }


### PR DESCRIPTION
Set HTTPS for the FastCGI server. This setting is required if you have another server handling the https.