### PR TITLE
Change php-alpine from latest to 3.13

### DIFF
--- a/alpine/5/Dockerfile
+++ b/alpine/5/Dockerfile
@@ -28,7 +28,7 @@ RUN npm install --production \
     && mv /var/www/app/public $BAK_PUBLIC_PATH  
 
 # Prepare php image
-FROM php:${PHP_VERSION}-fpm-alpine as prod
+FROM php:${PHP_VERSION}-fpm-alpine3.13 as prod
 ARG INVOICENINJA_VERSION
 ARG BAK_STORAGE_PATH
 ARG BAK_PUBLIC_PATH


### PR DESCRIPTION
Some bugs with alpine 3.14 at the moment. Set Alpine to 3.13 for the time being.

https://gitlab.alpinelinux.org/alpine/aports/-/issues/12763
https://github.com/mlocati/docker-php-extension-installer/issues/359