### PR TITLE
Extend liveness probe delay to prevent first migration failure

### DIFF
--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/invoiceninja/templates/deployment.yaml
+++ b/charts/invoiceninja/templates/deployment.yaml
@@ -135,8 +135,10 @@ spec:
             timeoutSeconds: {{ $.Values.livenessProbe.timeoutSeconds }}
             successThreshold: {{ $.Values.livenessProbe.successThreshold }}
             failureThreshold: {{ $.Values.livenessProbe.failureThreshold }}
-            tcpSocket:
-              port: {{ .Values.livenessProbe.port }}
+            exec:
+              command:
+              - pgrep
+              - php-fpm
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -294,12 +294,11 @@ service:
 ##
 livenessProbe:
   enabled: true
-  initialDelaySeconds: 30
+  initialDelaySeconds: 120
   periodSeconds: 10
   timeoutSeconds: 5
   failureThreshold: 6
   successThreshold: 1
-  port: fastcgi
 readinessProbe:
   enabled: true
   initialDelaySeconds: 15


### PR DESCRIPTION
Initial migration taking at least 1.5min on some computers
Extend time to prevent pod from being killed during this time.