### PR TITLE
Add Nginx to IN pod in chart

### DIFF
--- a/charts/invoiceninja/Chart.lock
+++ b/charts/invoiceninja/Chart.lock
@@ -11,5 +11,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 14.6.6
-digest: sha256:675a7e41183e23844b8c3c589e25c2fafccd394cd03710e0a2b35d72db436d70
-generated: "2021-07-08T00:30:57.000141+08:00"
+digest: sha256:a9dced490c24324a0d76821d94569c12b49a2f40d7dc8f6aa07c139f116bf5ec
+generated: "2021-07-09T20:05:19.280732+08:00"

--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.3
+version: 0.7.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -30,7 +30,8 @@ dependencies:
     tags:
       - bitnami-common
     version: 1.x.x
-  - name: nginx
+  - condition: nginx.enabled
+    name: nginx
     repository: https://charts.bitnami.com/bitnami
     version: 9.x.x
   - condition: mariadb.enabled

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -351,7 +351,7 @@ If you have the ability to use `ReadWriteMany` persistent volume access mode, us
 - built-in TLS functionality
 - high-availability
 
-However, since there are a lot of people without access to this volume type, using the inline Nginx web server will allow you to use a `ReadWriteOnce` public volume. Please note that you will need to change `persistence.public.accessModes` parameter and disable the Nginx sub-chart by setting `nginx.enabled` to false. Please note that you will be limited 1 IN replica.
+However, since there are a lot of people without access to this volume type, using the inline Nginx web server will allow you to use a `ReadWriteOnce` public volume. Please note that you will need to change `persistence.public.accessModes` parameter and disable the Nginx sub-chart by setting `nginx.enabled` to false. Also, you will be limited 1 IN replica.
 
 ## Upgrading
 

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -101,7 +101,7 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `readinessProbe`         | Readiness probe configuration for Invoice Ninja                               | Check `values.yaml` file                                |
 | `containerPorts.fastcgi` | FastCGI port to expose at container level                                     | `9000`                                                  |
 
-### Inline web server container parameters (when `nginx.enabled` is false)
+### Inline web server container parameters (only used when `nginx.enabled` is false)
 
 | Parameter                | Description                                              | Default                                                 |
 | ------------------------ | -------------------------------------------------------- | ------------------------------------------------------- |
@@ -168,7 +168,7 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `service.externalTrafficPolicy`    | Enable client source IP preservation                                       | `Cluster`                      |
 | `service.annotations`              | Service annotations                                                        | `{}` (evaluated as a template) |
 
-#### Inline web server (when `nginx.enabled` is false)
+#### Inline web server (only used when `nginx.enabled` is false)
 
 | Parameter                               | Description                                                                | Default                        |
 | --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------ |
@@ -186,8 +186,11 @@ The following table shows the configuration options for the Invoice Ninja helm c
 
 ### Ingress parameters 
 
+#### Nginx sub-chart
+
 | Parameter                            | Description                           | Default                                                |
 | ------------------------------------ | ------------------------------------- | ------------------------------------------------------ |
+| `nginx.enabled`                      | Deploy Nginx sub-chart                | `true`                                                 |
 | `nginx.service.type`                 | Kubernetes Service type               | `ClusterIP`                                            |
 | `nginx.ingress.enabled`              | Enable ingress controller resource    | `true`                                                 |
 | `nginx.ingress.hostname`             | Default host for the ingress resource | `invoiceninja.local`                                   |
@@ -195,6 +198,24 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `nginx.staticSitePVC`                | Name of Invoice Ninja public PVC      | `{{ include "invoiceninja.public.storageName" . }}`    |
 
 > See [Dependencies](#dependencies) for more.
+
+#### Inline web server (only used when `nginx.enabled` is false)
+
+| Parameter                  | Description                                                                                           | Default                  |
+| -------------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------ |
+| `ingress.enabled`          | Enable ingress                                                                                        | `true`                   |
+| `ingress.certManager`      | Add the corresponding annotations for cert-manager integration                                        | `false`                  |
+| `ingress.pathType`         | Ingress path type                                                                                     | `ImplementationSpecific` |
+| `ingress.apiVersion`       | Force Ingress API version (automatically detected if not set)                                         | `nil`                    |
+| `ingress.ingressClassName` | IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)                         | `nil`                    |
+| `ingress.hostname`         | Default host for the ingress record                                                                   | `invoiceninja.local`     |
+| `ingress.path`             | Default path for the ingress record                                                                   | `/`                      |
+| `ingress.annotations`      | Additional custom annotations for the ingress record                                                  | `{}`                     |
+| `ingress.tls`              | Enable TLS configuration for the host defined at `ingress.hostname` parameter                         | `false`                  |
+| `ingress.extraHosts`       | An array with additional hostname(s) to be covered with the ingress record                            | `[]`                     |
+| `ingress.extraPaths`       | An array with additional arbitrary paths that may need to be added to the ingress under the main host | `[]`                     |
+| `ingress.extraTls`         | TLS configuration for additional hostname(s) to be covered with this ingress record                   | `[]`                     |
+| `ingress.secrets`          | Custom TLS certificates as secrets                                                                    | `[]`                     |
 
 ### Persistence parameters
 

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -21,7 +21,7 @@ To install the chart with the release name `invoiceninja`:
 
 ```bash
 helm repo add invoiceninja https://invoiceninja.github.io/dockerfiles
-helm install invoiceninja invoiceninja/invoiceninja --set appKey=changeit --set mariadb.auth.rootPassword=changeit --set mariadb.auth.password=changeit --set redis.password=changeit
+helm install invoiceninja invoiceninja/invoiceninja --set appKey=changeit --set mariadb.auth.rootPassword=changeit --set mariadb.auth.password=changeit --set redis.auth.password=changeit
 ```
 
 The command deploys Invoice Ninja on the Kubernetes cluster in the default namespace. The [Parameters](#parameters) section lists the parameters that can be configured during installation.
@@ -68,46 +68,67 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `kubeVersion`       | Force target Kubernetes version (using Helm capabilities if not set) | `nil`                          |
 | `extraDeploy`       | Array of extra objects to deploy with the release                    | `[]` (evaluated as a template) |
 
-### Invoice Ninja parameters
+### Invoice Ninja container parameters
 
-| Parameter            | Description                                                                   | Default                                                 |
-| -------------------- | ----------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `image.registry`     | Invoice Ninja image registry                                                  | `docker.io`                                             |
-| `image.repository`   | Invoice Ninja image name                                                      | `invoiceninja/invoiceninja`                             |
-| `image.tag`          | Invoice Ninja image tag                                                       | Check `values.yaml` file                                |
-| `image.pullPolicy`   | Invoice Ninja image pull policy                                               | `IfNotPresent`                                          |
-| `image.pullSecrets`  | Specify docker-registry secret names as an array                              | `[]` (does not add image pull secrets to deployed pods) |
-| `image.debug`        | Specify if debug logs should be enabled                                       | `false`                                                 |
-| `serviceAccountName` | Name of a service account for the Invoice Ninja pods                          | `default`                                               |
-| `debug`              | Turn on debug mode on Invoice Ninja                                           | `false`                                                 |
-| `appKey`             | Laravel Application Key (ignored if existing secret is provided)              | _random 32 character alphanumeric string_               |
-| `userEmail`          | Initial user email address                                                    | `admin@example.com`                                     |
-| `userPassword`       | Initial user password (ignored if existing secret is provided)                | `changeme!`                                             |
-| `logChannel`         | Name of log channel to use                                                    | `nil`                                                   |
-| `broadcastDriver`    | Name of broadcast driver to use                                               | `nil`                                                   |
-| `cacheDriver`        | Name of cache driver to use                                                   | `nil`                                                   |
-| `sessionDriver`      | Name of session driver to use                                                 | `nil`                                                   |
-| `queueConnection`    | Name of queue connection to use                                               | `nil`                                                   |
-| `snappdf`            | Use snappdf instead of Phantom JS PDF generation                              | `true`                                                  |
-| `mailer`             | Name of the mailer to use (log, smtp, etc.)                                   | `log`                                                   |
-| `requireHttps`       | Force HTTPS for internal connections to Invoice Ninja (see #349)              | `false`                                                 |
-| `extraEnvVars`       | Extra environment variables to be set on Invoice Ninja container              | `{}`                                                    |
-| `extraEnvVarsCM`     | Name of existing ConfigMap containing extra env vars                          | `nil`                                                   |
-| `extraEnvVarsSecret` | Name of existing Secret containing extra env vars                             | `nil`                                                   |
-| `trustedProxy`       | List of trusted proxies for Invoice Ninja to communicate with the nginx proxy | `'*'`                                                   |
-| `existingSecret`     | Use existing secret that contain the keys `APP_KEY` and `IN_PASSWORD`         | `nil`                                                   |
+| Parameter                | Description                                                                   | Default                                                 |
+| ------------------------ | ----------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `image.registry`         | Invoice Ninja image registry                                                  | `docker.io`                                             |
+| `image.repository`       | Invoice Ninja image name                                                      | `invoiceninja/invoiceninja`                             |
+| `image.tag`              | Invoice Ninja image tag                                                       | Check `values.yaml` file                                |
+| `image.pullPolicy`       | Invoice Ninja image pull policy                                               | `IfNotPresent`                                          |
+| `image.pullSecrets`      | Specify docker-registry secret names as an array                              | `[]` (does not add image pull secrets to deployed pods) |
+| `image.debug`            | Specify if debug logs should be enabled                                       | `false`                                                 |
+| `debug`                  | Turn on debug mode on Invoice Ninja                                           | `false`                                                 |
+| `appKey`                 | Laravel Application Key (ignored if existing secret is provided)              | _random 32 character alphanumeric string_               |
+| `userEmail`              | Initial user email address                                                    | `admin@example.com`                                     |
+| `userPassword`           | Initial user password (ignored if existing secret is provided)                | `changeme!`                                             |
+| `logChannel`             | Name of log channel to use                                                    | `nil`                                                   |
+| `broadcastDriver`        | Name of broadcast driver to use                                               | `nil`                                                   |
+| `cacheDriver`            | Name of cache driver to use                                                   | `nil`                                                   |
+| `sessionDriver`          | Name of session driver to use                                                 | `nil`                                                   |
+| `queueConnection`        | Name of queue connection to use                                               | `nil`                                                   |
+| `snappdf`                | Use snappdf instead of Phantom JS PDF generation                              | `true`                                                  |
+| `mailer`                 | Name of the mailer to use (log, smtp, etc.)                                   | `log`                                                   |
+| `requireHttps`           | Force HTTPS for internal connections to Invoice Ninja (see #349)              | `false`                                                 |
+| `existingSecret`         | Use existing secret that contain the keys `APP_KEY` and `IN_PASSWORD`         | `nil`                                                   |
+| `extraEnvVars`           | Extra environment variables to be set on Invoice Ninja container              | `{}`                                                    |
+| `extraEnvVarsCM`         | Name of existing ConfigMap containing extra env vars                          | `nil`                                                   |
+| `extraEnvVarsSecret`     | Name of existing Secret containing extra env vars                             | `nil`                                                   |
+| `trustedProxy`           | List of trusted proxies for Invoice Ninja to communicate with the nginx proxy | `'*'`                                                   |
+| `extraVolumeMounts`      | Additional volume mounts                                                      | `[]`                                                    |
+| `resources`              | The resources for the Invoice Ninja container                                 | `{}`                                                    |
+| `livenessProbe`          | Liveness probe configuration for Invoice Ninja                                | Check `values.yaml` file                                |
+| `readinessProbe`         | Readiness probe configuration for Invoice Ninja                               | Check `values.yaml` file                                |
+| `containerPorts.fastcgi` | FastCGI port to expose at container level                                     | `9000`                                                  |
+
+### Inline web server container parameters (when `nginx.enabled` is false)
+
+| Parameter                | Description                                              | Default                                                 |
+| ------------------------ | -------------------------------------------------------- | ------------------------------------------------------- |
+| `http.image.registry`    | Nginx image registry                                     | `docker.io`                                             |
+| `http.image.repository`  | Nginx image name                                         | `invoiceninja/invoiceninja`                             |
+| `http.image.tag`         | Nginx image tag                                          | Check `values.yaml` file                                |
+| `http.image.pullPolicy`  | Nginx image pull policy                                  | `IfNotPresent`                                          |
+| `http.image.pullSecrets` | Specify docker-registry secret names as an array         | `[]` (does not add image pull secrets to deployed pods) |
+| `http.image.debug`       | Specify if debug logs should be enabled                  | `false`                                                 |
+| `extraEnvVars`           | Extra environment variables to be set on Nginx container | `{}`                                                    |
+| `extraEnvVarsCM`         | Name of existing ConfigMap containing extra env vars     | `nil`                                                   |
+| `extraEnvVarsSecret`     | Name of existing Secret containing extra env vars        | `nil`                                                   |
+| `extraVolumeMounts`      | Additional volume mounts                                 | `[]`                                                    |
+| `resources`              | The resources for the Nginx container                    | `{}`                                                    |
+| `livenessProbe`          | Liveness probe configuration for Nginx                   | Check `values.yaml` file                                |
+| `readinessProbe`         | Readiness probe configuration for Nginx                  | Check `values.yaml` file                                |
+| `containerPorts.http`    | HTTP port to expose at container level                   | `9000`                                                  |
+| `containerPorts.https`   | HTTPS port to expose at container level                  | `9000`                                                  |
 
 ### Invoice Ninja deployment parameters
 
 | Parameter                   | Description                                                                               | Default                        |
 | --------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------ |
 | `replicaCount`              | Number of Invoice Ninja Pods to run                                                       | `1`                            |
-| `containerPorts.fastcgi`    | FastCGI port to expose at container level                                                 | `9000`                         |
-| `podSecurityContext`        | Invoice Ninja pods' Security Context                                                      | Check `values.yaml` file       |
+| `serviceAccountName`        | Name of a service account for the Invoice Ninja pods                                      | `default`                      |
 | `containerSecurityContext`  | Invoice Ninja containers' Security Context                                                | Check `values.yaml` file       |
-| `resources`                 | The resources for the Invoice Ninja container                                             | `{}`                           |
-| `livenessProbe`             | Liveness probe configuration for Invoice Ninja                                            | Check `values.yaml` file       |
-| `readinessProbe`            | Readiness probe configuration for Invoice Ninja                                           | Check `values.yaml` file       |
+| `podSecurityContext`        | Invoice Ninja pods' Security Context                                                      | Check `values.yaml` file       |
 | `updateStrategy`            | Set up update strategy                                                                    | `RollingUpdate`                |
 | `podAntiAffinityPreset`     | Pod anti-affinity preset. Ignored if `affinity` is set. Allowed values: `soft` or `hard`  | `soft`                         |
 | `nodeAffinityPreset.type`   | Node affinity preset type. Ignored if `affinity` is set. Allowed values: `soft` or `hard` | `""`                           |
@@ -118,7 +139,6 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `tolerations`               | Tolerations for pod assignment                                                            | `[]` (evaluated as a template) |
 | `podLabels`                 | Extra labels for Invoice Ninja pods                                                       | `{}`                           |
 | `podAnnotations`            | Annotations for Invoice Ninja pods                                                        | `{}`                           |
-| `extraVolumeMounts`         | Additional volume mounts                                                                  | `[]`                           |
 | `extraVolumes`              | Additional volumes                                                                        | `[]`                           |
 
 ### Volume Permissions parameters
@@ -135,6 +155,8 @@ The following table shows the configuration options for the Invoice Ninja helm c
 
 ### Exposure parameters
 
+#### FastCGI
+
 | Parameter                          | Description                                                                | Default                        |
 | ---------------------------------- | -------------------------------------------------------------------------- | ------------------------------ |
 | `service.type`                     | Kubernetes Service type                                                    | `ClusterIP`                    |
@@ -145,6 +167,22 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `service.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                           | `nil`                          |
 | `service.externalTrafficPolicy`    | Enable client source IP preservation                                       | `Cluster`                      |
 | `service.annotations`              | Service annotations                                                        | `{}` (evaluated as a template) |
+
+#### Inline web server (when `nginx.enabled` is false)
+
+| Parameter                               | Description                                                                | Default                        |
+| --------------------------------------- | -------------------------------------------------------------------------- | ------------------------------ |
+| `service.http.type`                     | Kubernetes Service type                                                    | `ClusterIP`                    |
+| `service.http.ports.http`               | Service HTTP port                                                          | `9000`                         |
+| `service.http.ports.https`              | Service HTTPS port                                                         | `9000`                         |
+| `service.http.nodePorts.http`           | Kubernetes HTTP node port                                                  | `""`                           |
+| `service.http.nodePorts.https`          | Kubernetes HTTPS node port                                                 | `""`                           |
+| `service.http.clusterIP`                | Invoice Ninja service clusterIP IP                                         | `None`                         |
+| `service.http.loadBalancerSourceRanges` | Restricts access for LoadBalancer (only with `service.type: LoadBalancer`) | `[]`                           |
+| `service.http.loadBalancerIP`           | loadBalancerIP if service type is `LoadBalancer`                           | `nil`                          |
+| `service.http.externalTrafficPolicy`    | Enable client source IP preservation                                       | `Cluster`                      |
+| `service.http.annotations`              | Service annotations                                                        | `{}` (evaluated as a template) |
+
 
 ### Ingress parameters 
 
@@ -229,14 +267,13 @@ helm install invoiceninja \
   --set appKey=changeit \
   --set replicaCount=3 \
   --set nginx.replicaCount=3 \
-  --set redis.cluster.slaveCount=3 \
-  --set redis.password=changeit \
+  --set redis.auth.password=changeit \
   --set mariadb.auth.rootPassword=changeit \
   --set mariadb.auth.password=changeit \
   invoiceninja/invoiceninja
 ```
 
-The above command sets the number of replicas to 3 for a highly available (HA) setup. Note that you would need to use an external DB such as MariaDB Galera for a full HA production setup.
+The above command sets the number of replicas to 3 for a highly available (HA) setup. Note that you would need to use an external DB such as MariaDB Galera for a full HA production setup. For a production environment, it is recommended that you spin up the required databases in a separate Helm Chart to decouple the upgrading process.
 
 Alternatively, a YAML file that specifies the values for the parameters can be provided while [installing](https://helm.sh/docs/helm/helm_install/) the chart. For example,
 
@@ -282,6 +319,16 @@ kubectl create configmap examplemap --from-literal=MAIL_HOST='smtp.mailtrap.io'
 # ... values.yaml file
 extraEnvVarsCM: examplemap
 ```
+
+## Inline web server vs Nginx sub-chart
+
+If you have the ability to use `ReadWriteMany` persistent volume access mode, using the Nginx sub-chart will provide you with the most features, such as:
+
+- independent scaling of Nginx and IN pods
+- built in TLS functionality
+- high-availability
+
+However, since there are a great deal of people without access to this volume type, using the inline Nginx web server will allow you to use a `ReadWriteOnce` public volume. Please note that you will need to change `persistence.public.accessModes` parameter and disable Nginx sub-chart by setting `nginx.enabled` to false. Please note that you will be limited 1 IN replica.
 
 ## Upgrading
 

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -343,15 +343,15 @@ kubectl create configmap examplemap --from-literal=MAIL_HOST='smtp.mailtrap.io'
 extraEnvVarsCM: examplemap
 ```
 
-## Inline web server vs Nginx sub-chart
+## Inline webserver vs Nginx sub-chart
 
 If you have the ability to use `ReadWriteMany` persistent volume access mode, using the Nginx sub-chart will provide you with the most features, such as:
 
 - independent scaling of Nginx and IN pods
-- built in TLS functionality
+- built-in TLS functionality
 - high-availability
 
-However, since there are a great deal of people without access to this volume type, using the inline Nginx web server will allow you to use a `ReadWriteOnce` public volume. Please note that you will need to change `persistence.public.accessModes` parameter and disable Nginx sub-chart by setting `nginx.enabled` to false. Please note that you will be limited 1 IN replica.
+However, since there are a lot of people without access to this volume type, using the inline Nginx web server will allow you to use a `ReadWriteOnce` public volume. Please note that you will need to change `persistence.public.accessModes` parameter and disable the Nginx sub-chart by setting `nginx.enabled` to false. Please note that you will be limited 1 IN replica.
 
 ## Upgrading
 

--- a/charts/invoiceninja/templates/_helpers.tpl
+++ b/charts/invoiceninja/templates/_helpers.tpl
@@ -278,3 +278,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- define "invoiceninja.nginx.serverBlockName" -}}
 {{- printf "%s-%s" .Release.Name "server-block" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
+
+{{/*
+Name of web service for inline web server.
+*/}}
+{{- define "invoiceninja.http.serviceName" -}}
+{{- printf "%s-%s" .Release.Name "web" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}

--- a/charts/invoiceninja/templates/_helpers.tpl
+++ b/charts/invoiceninja/templates/_helpers.tpl
@@ -6,10 +6,17 @@ Return the proper image name
 {{- end -}}
 
 {{/*
+Return the proper image name
+*/}}
+{{- define "invoiceninja.nginx.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.http.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
 Return the proper Docker Image Registry Secret Names
 */}}
 {{- define "invoiceninja.imagePullSecrets" -}}
-{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.volumePermissions.image) "global" .Values.global) -}}
+{{- include "common.images.pullSecrets" (dict "images" (list .Values.image .Values.http.image .Values.volumePermissions.image) "global" .Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/charts/invoiceninja/templates/deployment.yaml
+++ b/charts/invoiceninja/templates/deployment.yaml
@@ -193,6 +193,61 @@ spec:
             {{- if .Values.extraVolumeMounts }}
               {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
+        {{- if not .Values.nginx.enabled }}
+        - name: nginx
+          securityContext:
+            {{- toYaml .Values.containerSecurityContext | nindent 12 }}
+          image: {{ include "invoiceninja.nginx.image" . }}
+          imagePullPolicy: {{ .Values.http.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.http.containerPort.http }}
+            - name: https
+              containerPort: {{ .Values.http.containerPort.https }}
+          {{- if .Values.http.livenessProbe.enabled }}
+          livenessProbe:
+            initialDelaySeconds: {{ .Values.http.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.http.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ $.Values.http.livenessProbe.timeoutSeconds }}
+            successThreshold: {{ $.Values.http.livenessProbe.successThreshold }}
+            failureThreshold: {{ $.Values.http.livenessProbe.failureThreshold }}
+            tcpSocket:
+              port: http
+          {{- end }}
+          {{- if .Values.http.readinessProbe.enabled }}
+          readinessProbe:
+            initialDelaySeconds: {{ .Values.http.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.http.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ $.Values.http.readinessProbe.timeoutSeconds }}
+            successThreshold: {{ $.Values.http.readinessProbe.successThreshold }}
+            failureThreshold: {{ $.Values.http.readinessProbe.failureThreshold }}
+            tcpSocket:
+              port: http
+          {{- end }}
+          envFrom:
+            {{- if .Values.http.extraEnvVarsCM }}
+            - configMapRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsCM "context" $) }}
+            {{- end }}
+            {{- if .Values.http.extraEnvVarsSecret }}
+            - secretRef:
+                name: {{ include "common.tplvalues.render" (dict "value" .Values.extraEnvVarsSecret "context" $) }}
+            {{- end }}
+          env:
+            {{- if .Values.http.extraEnvVars }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.extraEnvVars "context" $) | nindent 12 }}
+            {{- end }}
+          resources:
+            {{- toYaml .Values.http.resources | nindent 12 }}
+          volumeMounts:
+            - mountPath: /opt/bitnami/nginx/conf/server_blocks
+              name: nginx-server-block
+            - mountPath: /app
+              name: public
+            {{- if .Values.http.extraVolumeMounts }}
+              {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
+            {{- end }}
+        {{- end }}
       volumes:
         - name: public
           {{- if .Values.persistence.public.enabled }}
@@ -208,6 +263,12 @@ spec:
           {{- else }}
           emptyDir: {}
           {{ end }}
+        {{- if not .Values.nginx.enabled }}
+        - name: nginx-server-block
+          configMap:
+            defaultMode: 420
+            name: {{ include "invoiceninja.nginx.serverBlockName" . }}
+        {{- end }}
         {{- if .Values.extraVolumes }}
           {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumes "context" $) | nindent 8 }}
         {{- end }}

--- a/charts/invoiceninja/templates/deployment.yaml
+++ b/charts/invoiceninja/templates/deployment.yaml
@@ -201,9 +201,9 @@ spec:
           imagePullPolicy: {{ .Values.http.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: {{ .Values.http.containerPort.http }}
+              containerPort: {{ .Values.http.containerPorts.http }}
             - name: https
-              containerPort: {{ .Values.http.containerPort.https }}
+              containerPort: {{ .Values.http.containerPorts.https }}
           {{- if .Values.http.livenessProbe.enabled }}
           livenessProbe:
             initialDelaySeconds: {{ .Values.http.livenessProbe.initialDelaySeconds }}

--- a/charts/invoiceninja/templates/ingress.yaml
+++ b/charts/invoiceninja/templates/ingress.yaml
@@ -1,0 +1,63 @@
+{{- if and ( not .Values.nginx.enabled ) .Values.ingress.enabled }}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" . }}
+kind: Ingress
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace | quote }}
+  labels: {{- include "common.labels.standard" . | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  annotations:
+    {{- if .Values.ingress.certManager }}
+    kubernetes.io/tls-acme: "true"
+    {{- end }}
+    {{- if .Values.ingress.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+spec:
+  {{- if and .Values.ingress.ingressClassName (eq "true" (include "common.ingress.supportsIngressClassname" .)) }}
+  ingressClassName: {{ .Values.ingress.ingressClassName | quote }}
+  {{- end }}
+  rules:
+    {{- if .Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname | quote }}
+      http:
+        paths:
+          {{- if .Values.ingress.extraPaths }}
+          {{- toYaml .Values.ingress.extraPaths | nindent 10 }}
+          {{- end }}
+          - path: {{ .Values.ingress.path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" .) }}
+            pathType: {{ .Values.ingress.pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" ( dict "serviceName" (include "invoiceninja.http.serviceName" .) "servicePort" "http" "context" $ )  | nindent 14 }}
+    {{- end }}
+    {{- range .Values.ingress.extraHosts }}
+    - host: {{ .name | quote }}
+      http:
+        paths:
+          - path: {{ default "/" .path }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: {{ default "ImplementationSpecific" .pathType }}
+            {{- end }}
+            backend: {{- include "common.ingress.backend" ( dict "serviceName" (include "invoiceninja.http.serviceName" $) "servicePort" "http" "context" $ ) | nindent 14 }}
+    {{- end }}
+  {{- if or .Values.ingress.tls .Values.ingress.extraTls }}
+  tls:
+    {{- if .Values.ingress.tls }}
+    - hosts:
+        - {{ .Values.ingress.hostname | quote }}
+        {{- range .Values.ingress.extraHosts }}
+        - {{ .name | quote }}
+        {{- end }}
+      secretName: {{ printf "%s-tls" .Values.ingress.hostname }}
+    {{- end }}
+    {{- if .Values.ingress.extraTls }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.ingress.extraTls "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/invoiceninja/templates/webservice.yaml
+++ b/charts/invoiceninja/templates/webservice.yaml
@@ -1,0 +1,60 @@
+{{- if not .Values.nginx.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "common.names.fullname" . }}-web
+  labels:
+    {{- include "common.labels.standard" $ | nindent 4 }}
+    {{- if .Values.commonLabels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonLabels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.service.http.annotations .Values.commonAnnotations }}
+  annotations:
+    {{- if .Values.service.http.annotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.service.http.annotations "context" $ ) | nindent 4 }}
+    {{- end }}
+    {{- if .Values.commonAnnotations }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.commonAnnotations "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.http.type }}
+  {{- if and .Values.service.http.clusterIP (eq .Values.service.http.type "ClusterIP") }}
+  clusterIP: {{ .Values.service.http.clusterIP }}
+  {{- end }}
+  {{- if (or (eq .Values.service.http.type "LoadBalancer") (eq .Values.service.http.type "NodePort")) }}
+  externalTrafficPolicy: {{ .Values.service.http.externalTrafficPolicy | quote }}
+  {{- end }}
+  {{- if (and (eq .Values.service.http.type "LoadBalancer") .Values.service.http.loadBalancerSourceRanges) }}
+  loadBalancerSourceRanges: {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if (and (eq .Values.service.http.type "LoadBalancer") (not (empty .Values.service.http.loadBalancerIP))) }}
+  loadBalancerIP: {{ .Values.service.http.loadBalancerIP }}
+  {{- end }}
+  ports:
+    {{- if not (empty .Values.service.http.ports.http) }}
+    - name: http
+      port:  {{ .Values.service.http.ports.http }}
+      protocol: TCP
+      targetPort: http
+      {{- if (and (or (eq .Values.service.http.type "NodePort") (eq .Values.service.http.type "LoadBalancer")) (not (empty .Values.service.http.nodePorts.http))) }}
+      nodePort: {{ .Values.service.http.nodePorts.http }}
+      {{- else if eq .Values.service.http.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- end }}
+    {{- if not (empty .Values.service.http.ports.https) }}
+    - name: https
+      port:  {{ .Values.service.http.ports.https }}
+      protocol: TCP
+      targetPort: https
+      {{- if (and (or (eq .Values.service.http.type "NodePort") (eq .Values.service.http.type "LoadBalancer")) (not (empty .Values.service.http.nodePorts.https))) }}
+      nodePort: {{ .Values.service.http.nodePorts.https }}
+      {{- else if eq .Values.service.http.type "ClusterIP" }}
+      nodePort: null
+      {{- end }}
+    {{- end }}
+  selector:
+    {{- include "common.labels.matchLabels" . | nindent 4 }}
+    app.kubernetes.io/component: server
+{{- end }}

--- a/charts/invoiceninja/templates/webservice.yaml
+++ b/charts/invoiceninja/templates/webservice.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "common.names.fullname" . }}-web
+  name: {{ include "invoiceninja.http.serviceName" . }}
   labels:
     {{- include "common.labels.standard" $ | nindent 4 }}
     {{- if .Values.commonLabels }}

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -307,7 +307,7 @@ http:
 
   ## Container ports
   ##
-  containerPort:
+  containerPorts:
     http: 8080
     https: 8443
 

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -250,13 +250,122 @@ extraEnvVarsCM:
 ##
 extraEnvVarsSecret:
 
-## Extra volumes to add to the deployment
-##
-extraVolumes: []
-
 ## Extra volume mounts to add to the container
 ##
 extraVolumeMounts: []
+
+## Configure extra options for liveness and readiness probes
+## This applies to all the Invoice Ninja in the cluster
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+##
+livenessProbe:
+  enabled: true
+  initialDelaySeconds: 120
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+readinessProbe:
+  enabled: true
+  initialDelaySeconds: 15
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 6
+  successThreshold: 1
+  port: fastcgi
+
+resources:
+  {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+## Inline http server. This is enabled only if nginx sub chart is disabled.
+##
+http:
+  image:
+    registry: docker.io
+    repository: bitnami/nginx
+    tag: 1.21.1-debian-10-r0
+    ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+    ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+    ##
+    pullPolicy: IfNotPresent
+    ## Optionally specify an array of imagePullSecrets.
+    ## Secrets must be manually created in the namespace.
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+    ##
+    # pullSecrets:
+    #   - myRegistryKeySecretName
+
+  ## Container ports
+  ##
+  containerPort:
+    http: 8080
+    https: 8443
+
+  ## An array to add extra env vars
+  ## Example:
+  ## extraEnvVars:
+  ##   - name: FOO
+  ##     value: "bar"
+  ##
+  extraEnvVars: []
+
+  ## ConfigMap with extra environment variables
+  ##
+  extraEnvVarsCM:
+
+  ## Secret with extra environment variables
+  ##
+  extraEnvVarsSecret:
+
+  ## Extra volume mounts to add to the container
+  ##
+  extraVolumeMounts: []
+
+  ## Configure extra options for liveness and readiness probes
+  ## This applies to all the web server in the cluster
+  ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
+  ##
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 15
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 6
+    successThreshold: 1
+
+  resources:
+    {}
+    # We usually recommend not to specify default resources and to leave this as a conscious
+    # choice for the user. This also increases chances charts run on environments with little
+    # resources, such as Minikube. If you do want to specify resources, uncomment the following
+    # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    # limits:
+    #   cpu: 100m
+    #   memory: 128Mi
+    # requests:
+    #   cpu: 100m
+    #   memory: 128Mi
+
+## Extra volumes to add to the deployment
+##
+extraVolumes: []
 
 ## Kubernetes service type
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/
@@ -293,39 +402,43 @@ service:
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
   ##
   annotations: {}
-
-## Configure extra options for liveness and readiness probes
-## This applies to all the Invoice Ninja in the sharded cluster
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes)
-##
-livenessProbe:
-  enabled: true
-  initialDelaySeconds: 120
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-readinessProbe:
-  enabled: true
-  initialDelaySeconds: 15
-  periodSeconds: 10
-  timeoutSeconds: 5
-  failureThreshold: 6
-  successThreshold: 1
-  port: fastcgi
-
-resources:
-  {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+  ## Service for http server
+  ##
+  http:
+    ## Service type
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types
+    ##
+    type: ClusterIP
+    ## Service ports
+    ##
+    ports:
+      http: 8080
+      https: 8443
+    ## Specify the nodePort value for the LoadBalancer and NodePort service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+    ##
+    nodePorts:
+      http: ""
+      https: ""
+    ## Service clusterIP.
+    ##
+    # clusterIP: None
+    ## Specify the loadBalancerIP value for LoadBalancer service types.
+    ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer
+    ##
+    # loadBalancerIP:
+    ## Specify the loadBalancerSourceRanges value for LoadBalancer service types.
+    ## ref: https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+    ##
+    loadBalancerSourceRanges: []
+    ## Enable client source IP preservation
+    ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+    ##
+    externalTrafficPolicy: Cluster
+    ## Additional service annotations (evaluate as a template)
+    ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
+    ##
+    annotations: {}
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
@@ -464,6 +577,7 @@ externalDatabase:
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/nginx/values.yaml
 ##
 nginx:
+  enabled: true
   service:
     ## Service type
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -287,7 +287,7 @@ resources:
   #   cpu: 100m
   #   memory: 128Mi
 
-## Inline http server. This is enabled only if nginx sub chart is disabled.
+## Inline http server (this is enabled only if nginx sub chart is disabled).
 ##
 http:
   image:
@@ -439,6 +439,92 @@ service:
     ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
     ##
     annotations: {}
+
+## Configure the ingress resource to access IN (this is enabled only if nginx sub chart is disabled).
+## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/
+##
+ingress:
+  ## Enable ingress
+  ##
+  enabled: true
+  ## Add the corresponding annotations for cert-manager integration
+  ##
+  certManager: false
+  ## Ingress path type
+  ##
+  pathType: ImplementationSpecific
+  ## Force Ingress API version (automatically detected if not set)
+  ##
+  apiVersion:
+  ## IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+  ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+  ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+  ##
+  ingressClassName:
+  ## Default host for the ingress record
+  ##
+  hostname: invoiceninja.local
+  ## Default path for the ingress record
+  ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+  ##
+  path: /
+  ## Additional custom annotations for the ingress record
+  ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
+  ##
+  annotations: {}
+  ## Enable TLS configuration for the host defined at `ingress.hostname` parameter
+  ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+  ## You can:
+  ##   - Use the `ingress.secrets` parameter to create this TLS secret
+  ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+  ##   - Relay on Helm to create self-signed certificates by setting `ingress.tls=true` and `ingress.certManager=false`
+  ##
+  tls: false
+  ## An array with additional hostname(s) to be covered with the ingress record
+  ## e.g:
+  ## extraHosts:
+  ##   - name: invoiceninja.local
+  ##     path: /
+  ##
+  extraHosts: []
+  ## An array with additional arbitrary paths that may need to be added to the ingress under the main host
+  ## e.g:
+  ## extraPaths:
+  ## - path: /*
+  ##   backend:
+  ##     serviceName: ssl-redirect
+  ##     servicePort: use-annotation
+  ##
+  extraPaths: []
+  ## TLS configuration for additional hostname(s) to be covered with this ingress record
+  ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+  ## e.g:
+  ## extraTls:
+  ## - hosts:
+  ##     - invoiceninja.local
+  ##   secretName: invoiceninja.local-tls
+  ##
+  extraTls: []
+  ## Custom TLS certificates as secrets
+  ## NOTE: 'key' and 'certificate' are expected in PEM format
+  ## NOTE: 'name' should line up with a 'secretName' set further up
+  ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+  ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+  ## It is also possible to create and manage the certificates outside of this helm chart
+  ## Please see README.md for more information
+  ## e.g:
+  ## secrets:
+  ##   - name: invoiceninja.local-tls
+  ##     key: |-
+  ##       -----BEGIN RSA PRIVATE KEY-----
+  ##       ...
+  ##       -----END RSA PRIVATE KEY-----
+  ##     certificate: |-
+  ##       -----BEGIN CERTIFICATE-----
+  ##       ...
+  ##       -----END CERTIFICATE-----
+  ##
+  secrets: []
 
 ## Enable persistence using Persistent Volume Claims
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/


### PR DESCRIPTION
Inline webserver vs Nginx sub-chart

If you have the ability to use `ReadWriteMany` persistent volume access mode, using the Nginx sub-chart will provide you with the most features, such as:

- independent scaling of Nginx and IN pods
- built-in TLS functionality
- high-availability

However, since there are a lot of people without access to this volume type, using the inline Nginx web server will allow you to use a `ReadWriteOnce` public volume. Please note that you will need to change `persistence.public.accessModes` parameter and disable the Nginx sub-chart by setting `nginx.enabled` to false. Please note that you will be limited 1 IN replica.
