### PR TITLE
Release Candidate and change PDF generation key

### DIFF
--- a/charts/invoiceninja/Chart.lock
+++ b/charts/invoiceninja/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 9.3.6
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.16
+  version: 9.3.17
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 14.6.6
-digest: sha256:a9dced490c24324a0d76821d94569c12b49a2f40d7dc8f6aa07c139f116bf5ec
-generated: "2021-07-09T20:05:19.280732+08:00"
+  version: 14.7.0
+digest: sha256:db43a7dbdb82772721afbebfb1d4011b00b004b2eac0a3b8670fb6761eab1900
+generated: "2021-07-14T18:20:52.796093+08:00"

--- a/charts/invoiceninja/Chart.lock
+++ b/charts/invoiceninja/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 1.7.0
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.6
+  version: 9.3.7
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
   version: 9.3.17
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 14.7.0
-digest: sha256:db43a7dbdb82772721afbebfb1d4011b00b004b2eac0a3b8670fb6761eab1900
-generated: "2021-07-14T18:20:52.796093+08:00"
+  version: 14.7.1
+digest: sha256:495d7cedf5284501249705101853f33d1bb479b35ce11a518631682cdb38c15f
+generated: "2021-07-16T00:53:22.586326+08:00"

--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -13,11 +13,11 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.8
+version: 0.8.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 5.2.10
+appVersion: 5.2.12
 keywords:
   - invoiceninja
 home: https://invoiceninja.github.io/dockerfiles

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -245,7 +245,7 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `redis.auth.password`             | Redis password                               | _random 10 character alphanumeric string_ |
 | `redis.auth.sentinel`             | Use password for sentinel containers         | `false`                                   |
 | `redis.sentinel.enabled`          | Enable sentinel containers                   | `true`                                    |
-| `replica.replicaCount`            | Number of Redis replicas to deploy           | `1`                                       |
+| `redis.replica.replicaCount`            | Number of Redis replicas to deploy           | `1`                                       |
 | `externalRedis.host`              | Host of the external redis                   | `nil`                                     |
 | `externalRedis.port`              | Port of the external redis                   | `6379`                                    |
 | `externalRedis.password`          | Password for the external redis              | `nil`                                     |
@@ -364,7 +364,7 @@ To improve the accessibility of this chart to regular users. Some of the default
 
 - `persistence.public.accessModes` now defaults to `ReadWriteOnce`.
 - `nginx.enabled` now defaults to false.
-- `replica.replicaCount` now defaults to `1`.
+- `redis.replica.replicaCount` now defaults to `1`.
 
 Other changes:
 

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -245,7 +245,8 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `redis.auth.password`             | Redis password                               | _random 10 character alphanumeric string_ |
 | `redis.auth.sentinel`             | Use password for sentinel containers         | `false`                                   |
 | `redis.sentinel.enabled`          | Enable sentinel containers                   | `true`                                    |
-| `redis.replica.replicaCount`            | Number of Redis replicas to deploy           | `1`                                       |
+| `redis.sentinel.quorum`           | Sentinel Quorum                              | `1`                                       |
+| `redis.replica.replicaCount`      | Number of Redis replicas to deploy           | `1`                                       |
 | `externalRedis.host`              | Host of the external redis                   | `nil`                                     |
 | `externalRedis.port`              | Port of the external redis                   | `6379`                                    |
 | `externalRedis.password`          | Password for the external redis              | `nil`                                     |
@@ -293,6 +294,7 @@ helm install invoiceninja \
   --set replicaCount=3 \
   --set persistence.public.accessModes[0]=ReadWriteMany
   --set redis.auth.password=changeit \
+  --set redis.sentinel.quorum=2 \
   --set redis.replica.replicaCount=3 \
   --set mariadb.auth.rootPassword=changeit \
   --set mariadb.auth.password=changeit \
@@ -364,7 +366,7 @@ To improve the accessibility of this chart to regular users. Some of the default
 
 - `persistence.public.accessModes` now defaults to `ReadWriteOnce`.
 - `nginx.enabled` now defaults to false.
-- `redis.replica.replicaCount` now defaults to `1`.
+- `redis.replica.replicaCount` and `redis.sentinel.quorum` now defaults to `1`.
 
 Other changes:
 

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -88,7 +88,7 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `cacheDriver`            | Name of cache driver to use                                                   | `nil`                                                   |
 | `sessionDriver`          | Name of session driver to use                                                 | `nil`                                                   |
 | `queueConnection`        | Name of queue connection to use                                               | `nil`                                                   |
-| `snappdf`                | Use snappdf instead of Phantom JS PDF generation                              | `true`                                                  |
+| `pdfGenerator`           | PDF generation method (Allowed values: `snappdf` or `phantom`)                | `snappdf`                                               |
 | `mailer`                 | Name of the mailer to use (log, smtp, etc.)                                   | `log`                                                   |
 | `requireHttps`           | Force HTTPS for internal connections to Invoice Ninja (see #349)              | `false`                                                 |
 | `existingSecret`         | Use existing secret that contain the keys `APP_KEY` and `IN_PASSWORD`         | `nil`                                                   |
@@ -228,7 +228,7 @@ The following table shows the configuration options for the Invoice Ninja helm c
 | `persistence.public.accessModes`    | PVC Access Modes                                    | `[ReadWriteMany]` |
 | `persistence.public.size`           | PVC Storage Request                                 | `1Gi`             |
 | `persistence.public.dataSource`     | PVC data source                                     | `{}`              |
-| `persistence.storage.enabled`       | Enable persistence using PVC (only for FILE driver) | `false`            |
+| `persistence.storage.enabled`       | Enable persistence using PVC (only for FILE driver) | `false`           |
 | `persistence.storage.existingClaim` | Enable persistence using an existing PVC            | `nil`             |
 | `persistence.storage.storageClass`  | PVC Storage Class                                   | `nil`             |
 | `persistence.storage.accessModes`   | PVC Access Modes                                    | `[ReadWriteMany]` |
@@ -356,7 +356,11 @@ However, since there are a lot of people without access to this volume type, usi
 
 ## Upgrading
 
+### To 0.8.0
+
+- `snappdf` option has been replaced by `pdfGenerator`.
+
 ### To 0.7.0
 
 - Redis chart dependency has been upgraded and may not be backwards compatible with previous versions. See [here](https://github.com/bitnami/charts/tree/master/bitnami/redis) for more info.
-- Storage persitence defaults to `false`, set to `true` if not using Redis, or using any FILE driver
+- Storage persitence defaults to `false`. Set to `true` if not using Redis or using FILE driver

--- a/charts/invoiceninja/templates/configmap.yaml
+++ b/charts/invoiceninja/templates/configmap.yaml
@@ -44,7 +44,9 @@ data:
   {{- else if or .Values.redis.enabled .Values.externalRedis.host }}
   QUEUE_CONNECTION: redis
   {{- end }}
-  PHANTOMJS_PDF_GENERATION: {{ not .Values.snappdf | quote}}
+  # PHANTOMJS_PDF_GENERATION is deprecated
+  PHANTOMJS_PDF_GENERATION: "false"
+  PDF_GENERATOR: {{ .Values.pdfGenerator | quote}}
   REDIS_HOST: {{ include "invoiceninja.redisHost" . | quote }}
   REDIS_PORT: {{ include "invoiceninja.redisPort" . | quote }}
   REDIS_DB: {{ include "invoiceninja.redisDatabase" . | quote }}

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -549,7 +549,7 @@ persistence:
     ## If you want to reuse an existing claim, you can pass the name of the PVC using
     ## the existingClaim variable
     # existingClaim: your-claim
-    accessMode: ReadWriteMany
+    accessMode: ReadWriteOnce
     size: 1Gi
     ## Custom dataSource
     ##
@@ -669,7 +669,7 @@ externalDatabase:
 ## ref: https://github.com/bitnami/charts/blob/master/bitnami/nginx/values.yaml
 ##
 nginx:
-  enabled: true
+  enabled: false
   service:
     ## Service type
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: invoiceninja/invoiceninja
-  tag: 5.2.11
+  tag: 5.2.12
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##
@@ -77,8 +77,9 @@ queueConnection: ""
 trustedProxies: "*"
 
 ## Use local or Phantom JS PDF generation
+## Options are `snappdf` or `phantom`
 ##
-snappdf: true
+pdfGenerator: snappdf
 
 ## Name of queue connection to use (use "log" for debug)
 ## Please check the ref below for any other env you may need to define

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -591,6 +591,8 @@ redis:
     sentinel: false
   sentinel:
     enabled: true
+  replica:
+    replicaCount: 1
 
 ## External Redis Configuration
 ##

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -591,6 +591,7 @@ redis:
     sentinel: false
   sentinel:
     enabled: true
+    quorum: 1
   replica:
     replicaCount: 1
 


### PR DESCRIPTION
`snappdf` option has been replaced by `pdfGenerator`.

It seems like most issues in this chart have been addressed. So this version is a release candidate for v1.0.0

