### PR TITLE
 #391 mysqladmin ping timeout from 12 hours to 15 seconds

### DIFF
--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.8.0
+version: 0.8.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/invoiceninja/templates/deployment.yaml
+++ b/charts/invoiceninja/templates/deployment.yaml
@@ -66,7 +66,7 @@ spec:
               [[ -z "${DB_HOST1}" ]] || DB_HOST="${DB_HOST1}";
               [[ -z "${DB_PORT1}" ]] || DB_PORT="${DB_PORT1}";
               while [ $COUNTER -lt 120 ]; do
-                if mysqladmin ping -h "$DB_HOST" -P $DB_PORT --silent; then
+                if mysqladmin ping -h "$DB_HOST" -P $DB_PORT --connect-timeout=15 --silent; then
                   exit 0;
                 fi;
                 let COUNTER=COUNTER+1;


### PR DESCRIPTION
As discussed at  #391, reduced default timeout (12 h) to 15 seconds for wait-db init container. This can be triggered by istio mTLS strict configuration, which requires an up and running envoy proxy. Envoy is started after init-phase.