### PR TITLE
Escape email and password upon IN User Creation

### DIFF
--- a/alpine/5/rootfs/docker-entrypoint-init.d/10-init-in.sh
+++ b/alpine/5/rootfs/docker-entrypoint-init.d/10-init-in.sh
@@ -3,12 +3,13 @@
 php artisan db:seed --force
 
 # Build up array of arguments...
+# We escape the env variables in order to allow special characters
 if [[ ! -z "${IN_USER_EMAIL}" ]]; then
-    email="--email ${IN_USER_EMAIL}"
+    email="--email \"${IN_USER_EMAIL}\""
 fi
 
 if [[ ! -z "${IN_PASSWORD}" ]]; then
-    password="--password ${IN_PASSWORD}"
+    password="--password \"${IN_PASSWORD}\""
 fi
 
 php artisan ninja:create-account $email $password


### PR DESCRIPTION
Fixes #415

Unsure if this is the _best_ fix, as I believe somebody could still break this by adding a `"` as part of their password? It should go most of the way though. Second opinions appreciated.