### PR TITLE
[FEATURE] Add support for mysql version 8

### DIFF
--- a/config/mysql/Dockerfile
+++ b/config/mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql:5-debian
+FROM mysql:8.0-debian
 # When running on ARM64 use MariaDB instead of MySQL
 #FROM mariadb:10.4
 ENV force_color_prompt yes

--- a/config/mysql/my.cnf
+++ b/config/mysql/my.cnf
@@ -1,0 +1,3 @@
+[mysqld]
+default-authentication-plugin=mysql_native_password
+bind-address=0.0.0.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,7 +38,8 @@ services:
       - "in5.localhost:192.168.0.124 " #host and ip
 
   db:
-    image: mysql:5-debian
+    image: mysql:8.0-debian
+    command: --default-authentication-plugin=mysql_native_password
 #    When running on ARM64 use MariaDB instead of MySQL
 #    image: mariadb:10.4
 #    For auto DB backups comment out image and use the build block below
@@ -50,6 +51,7 @@ services:
     env_file: env
     volumes:
       - ./docker/mysql/data:/var/lib/mysql:rw,delegated
+      - ./config/mysql/my.cnf:/etc/mysql/conf.d/z_my.cnf:ro
 
       # remove comments for next 4 lines if you want auto sql backups
       #- ./docker/mysql/bak:/backups:rw


### PR DESCRIPTION
I thought it might be handy to be able to use mysql 8 for further developments.

I have switched from mysql 5 to 8. Consciously to version 8.0 because in future versions the support of the small detour via 
```
command: --default-authentication-plugin=mysql_native_password
```
is omitted.