### PR TITLE
Update chart dependencies

### DIFF
--- a/charts/invoiceninja/Chart.lock
+++ b/charts/invoiceninja/Chart.lock
@@ -1,15 +1,15 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.7.0
+  version: 1.17.1
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.7
+  version: 13.2.20
 - name: mariadb
   repository: https://charts.bitnami.com/bitnami
-  version: 9.3.17
+  version: 11.4.2
 - name: redis
   repository: https://charts.bitnami.com/bitnami
-  version: 14.7.1
-digest: sha256:495d7cedf5284501249705101853f33d1bb479b35ce11a518631682cdb38c15f
-generated: "2021-07-16T00:53:22.586326+08:00"
+  version: 16.13.2
+digest: sha256:c60712ee5ca51c18136046f755c54a36fc46342356da92f891719af4a2991405
+generated: "2022-12-22T23:15:30.045985+08:00"

--- a/charts/invoiceninja/Chart.lock
+++ b/charts/invoiceninja/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 1.17.1
+  version: 2.2.2
 - name: nginx
   repository: https://charts.bitnami.com/bitnami
   version: 13.2.20
@@ -11,5 +11,5 @@ dependencies:
 - name: redis
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
-digest: sha256:c60712ee5ca51c18136046f755c54a36fc46342356da92f891719af4a2991405
-generated: "2022-12-22T23:15:30.045985+08:00"
+digest: sha256:da0dca54f32ca0465f89744d6247421ad13c907f09cd40fb21985c81888aaef1
+generated: "2022-12-22T23:33:23.007968+08:00"

--- a/charts/invoiceninja/Chart.lock
+++ b/charts/invoiceninja/Chart.lock
@@ -12,4 +12,4 @@ dependencies:
   repository: https://charts.bitnami.com/bitnami
   version: 16.13.2
 digest: sha256:da0dca54f32ca0465f89744d6247421ad13c907f09cd40fb21985c81888aaef1
-generated: "2022-12-22T23:33:23.007968+08:00"
+generated: "2022-12-23T00:18:09.129967+08:00"

--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -17,7 +17,7 @@ version: 0.10.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 5.3.80
+appVersion: 5.5.49
 keywords:
   - invoiceninja
 home: https://invoiceninja.github.io/dockerfiles
@@ -29,7 +29,7 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     tags:
       - bitnami-common
-    version: 1.x.x
+    version: 2.x.x
   - condition: nginx.enabled
     name: nginx
     repository: https://charts.bitnami.com/bitnami

--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.9.2
+version: 0.10.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
@@ -33,15 +33,15 @@ dependencies:
   - condition: nginx.enabled
     name: nginx
     repository: https://charts.bitnami.com/bitnami
-    version: 9.x.x
+    version: 13.x.x
   - condition: mariadb.enabled
     name: mariadb
     repository: https://charts.bitnami.com/bitnami
-    version: 9.3.x
+    version: 11.4.x
   - condition: redis.enabled
     name: redis
     repository: https://charts.bitnami.com/bitnami
-    version: 14.x.x
+    version: 16.x.x
 maintainers:
   - email: lwj5@hotmail.com
     name: lwj5

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -360,6 +360,16 @@ If you have the ability to use `ReadWriteMany` persistent volume, you can choose
 
 ## Upgrading
 
+### To 0.10.0
+
+The following chart dependencies have been upgraded.
+- MariaDB 
+- Redis
+- Nginx
+- Bitnami common
+
+Please take note that this upgrade MariaDB from 10.5 to 10.6. Please backup your database before proceeding.
+
 ### To 0.8.0
 
 To improve the accessibility of this chart to regular users. Some of the defaults have been changed. This include:

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -18,7 +18,7 @@
 image:
   registry: docker.io
   repository: invoiceninja/invoiceninja
-  tag: 5.3.80
+  tag: 5.5.49
   ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
   ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
   ##


### PR DESCRIPTION
The chart dependencies are fairly outdated and no longer offered by bitnami.

Hence the update.
