### PR TITLE
Add IPv6 support to chart

### DIFF
--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.10.0
+version: 0.10.1
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/invoiceninja/templates/serverblock.yaml
+++ b/charts/invoiceninja/templates/serverblock.yaml
@@ -15,6 +15,7 @@ data:
   server-block.conf: |-
     server {
         listen 8080 default_server;
+        listen [::]:8080 default_server;
         server_name _;
 
         root /app;

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -298,7 +298,7 @@ http:
   image:
     registry: docker.io
     repository: bitnami/nginx
-    tag: 1.21.1-debian-10-r0
+    tag: 1.22.1-debian-11-r21
     ## Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
     ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
     ##


### PR DESCRIPTION
The deployed chart now supports IPv6 clusters.