### PR TITLE
disable nginx version output

### DIFF
--- a/config/nginx/in-vhost.conf
+++ b/config/nginx/in-vhost.conf
@@ -1,7 +1,9 @@
 server {
     listen 80 default_server;
     server_name _;
-
+    
+    server_tokens off;
+    
     client_max_body_size 100M;
 
     root /var/www/app/public/;


### PR DESCRIPTION
Add `server_tokens off;` to not display nginx version in HTTP headers output.

server_tokens on:
server: nginx/1.23.3

server_tokens off:
server: nginx