### PR TITLE
Please don't bind mysql to all interfaces with default credentials in Docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,6 @@ services:
 #    For auto DB backups comment out image and use the build block below
 #    build:
 #      context: ./config/mysql
-    ports:
-      - "3305:3306"
     restart: always
     env_file: env
     volumes:


### PR DESCRIPTION
Please don't do this. Default credentials on the sql container in the .env file and then bind blindly 3305 on all interfaces for the public  to log in with ninja//ninja