### PR TITLE
use php 7.4 in invoiceninja v4 image

### DIFF
--- a/alpine/4/Dockerfile
+++ b/alpine/4/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP_VERSION=7.3
+ARG PHP_VERSION=7.4
 ARG BAK_STORAGE_PATH=/var/www/app/docker-backup-storage/
 ARG BAK_PUBLIC_PATH=/var/www/app/docker-backup-public/
 


### PR DESCRIPTION
When attempting to run the [`4.50.51`](https://hub.docker.com/layers/invoiceninja/invoiceninja/4.5.51/images/sha256-cc8fbe99b078042d1a1f69b2ae6c7d19eff7c3429b76207e5214f96916848704?context=explore) docker tag, I got an error as soon as the docker container starts:

```
dockerfiles-app-1     | Your Composer dependencies require a PHP version ">= 7.4.0". You are
```

This seems to happen as soon as php artisan runs in the container init script: 

https://github.com/invoiceninja/dockerfiles/blob/master/alpine/4/rootfs/usr/local/bin/laravel-init.sh#L3