### PR TITLE
feat(helm): permit specifying additionalServerBlockConfig

### DIFF
--- a/charts/invoiceninja/templates/serverblock.yaml
+++ b/charts/invoiceninja/templates/serverblock.yaml
@@ -37,4 +37,9 @@ data:
             fastcgi_buffer_size 16k;
             fastcgi_buffers 4 16k;
         }
+
+{{ if .Values.ingress.additionalServerBlockConfig }}
+{{ .Values.ingress.additionalServerBlockConfig | indent 8 }}
+{{ end }}
+
     }

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -473,6 +473,14 @@ ingress:
   ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
   ##
   path: /
+  ## Additional serverBlockConfig for nginx
+  ## Could be used to prevent caching of PDF when using a CDN (such as Cloudlfare) in front of InvoiceNinja
+  ## e.g.:
+  # additionalServerBlockConfig: |-
+  #   location ~* \.pdf$ {
+  #     add_header Cache-Control no-store;
+  #   }
+  additionalServerBlockConfig:
   ## Additional custom annotations for the ingress record
   ## NOTE: If `ingress.certManager=true`, annotation `kubernetes.io/tls-acme: "true"` will automatically be added
   ##


### PR DESCRIPTION
permits configuring an additional serverBlockConfig for nginx which can be used to prevent caching of PDFs when using a CDN (such as Cloudlfare) in front of InvoiceNinja, as documented in the troubleshooting section:

https://invoiceninja.github.io/en/self-host-troubleshooting/#pdfs-dont-appear-to-be-updating