### PR TITLE
Enable gzip and use laravel error_page for php files

### DIFF
--- a/config/nginx/in-vhost.conf
+++ b/config/nginx/in-vhost.conf
@@ -14,6 +14,8 @@ server {
     gzip_proxied no-cache no-store private expired auth;
     gzip_min_length 1000;
 
+    error_page 404 /index.php;
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
     }
@@ -27,6 +29,7 @@ server {
     }
 
     location ~ \.php$ {
+        try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass app:9000;
         fastcgi_index index.php;

--- a/config/nginx/in-vhost.conf
+++ b/config/nginx/in-vhost.conf
@@ -9,6 +9,11 @@ server {
     root /var/www/app/public/;
     index index.php;
 
+    gzip on;
+    gzip_types application/javascript application/x-javascript text/javascript text/plain application/xml application/json;
+    gzip_proxied no-cache no-store private expired auth;
+    gzip_min_length 1000;
+
     location / {
         try_files $uri $uri/ /index.php?$query_string;
     }


### PR DESCRIPTION
1. Activate gzip as described in the documentation https://invoiceninja.github.io/en/self-host-installation/
2. Set error_page as described in the laravel documentation https://laravel.com/docs/master/deployment#nginx. `try_files $uri =404;`will catch e.g https://example.com/some_file.php
