### PR TITLE
553: Add supPath value

### DIFF
--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -222,6 +222,7 @@ The following table shows the configuration options for the Invoice Ninja helm c
 
 | Parameter                           | Description                                         | Default           |
 | ----------------------------------- | --------------------------------------------------- | ----------------- |
+| `persistence.subPath`               | PVC sub path (applies to `public` and `storage`)    | `nil`             |
 | `persistence.public.enabled`        | Enable persistence using PVC                        | `true`            |
 | `persistence.public.existingClaim`  | Enable persistence using an existing PVC            | `nil`             |
 | `persistence.public.storageClass`   | PVC Storage Class                                   | `nil`             |

--- a/charts/invoiceninja/templates/deployment.yaml
+++ b/charts/invoiceninja/templates/deployment.yaml
@@ -112,8 +112,14 @@ spec:
           volumeMounts:
             - mountPath: /var/www/app/public
               name: public
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
             - mountPath: /var/www/app/storage
               name: storage
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
         {{- end }}
         {{- if .Values.initContainers }}
           {{- include "common.tplvalues.render" (dict "value" .Values.initContainers "context" $) | nindent 8 }}
@@ -188,8 +194,14 @@ spec:
           volumeMounts:
             - mountPath: /var/www/app/public
               name: public
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
             - mountPath: /var/www/app/storage
               name: storage
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
             {{- if .Values.extraVolumeMounts }}
               {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}
@@ -244,6 +256,9 @@ spec:
               name: nginx-server-block
             - mountPath: /app
               name: public
+              {{- if .Values.persistence.subPath }}
+              subPath: {{ .Values.persistence.subPath }}
+              {{- end }}
             {{- if .Values.http.extraVolumeMounts }}
               {{- include "common.tplvalues.render" (dict "value" .Values.extraVolumeMounts "context" $) | nindent 12 }}
             {{- end }}

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -535,6 +535,10 @@ ingress:
 ## ref: http://kubernetes.io/docs/user-guide/persistent-volumes/
 ##
 persistence:
+  ## Custom subPath
+  ## If the storage provider uses ext4 filesystems, a subPath is necessary to avoid
+  ## permissions issues with the `lost+found` folder at the root of the volume
+  # subPath: ""
   public:
     enabled: true
     ## Invoice Ninja data Persistent Volume Storage Class


### PR DESCRIPTION
Resolves #553 

This PR adds an optional `persistence.subPath` value to the helm chart, enabling ext4 formatted persistent storage volumes to be used with Invoice Ninja 