### PR TITLE
Fix Docker builds for circular dependency in project

### DIFF
--- a/alpine/5/Dockerfile
+++ b/alpine/5/Dockerfile
@@ -115,16 +115,6 @@ FROM phpbuild as prod
 
 COPY --from=dependencybuild --chown=$INVOICENINJA_USER:$INVOICENINJA_USER /var/www/app /var/www/app
 
-WORKDIR /var/www/app/
-
-# Install node packages
-ARG BAK_STORAGE_PATH
-ARG BAK_PUBLIC_PATH
-RUN npm install 
-RUN npm run production 
-RUN mv /var/www/app/storage $BAK_STORAGE_PATH 
-RUN mv /var/www/app/public $BAK_PUBLIC_PATH  
-
 # Override the environment settings from projects .env file
 ENV APP_ENV production
 ENV LOG errorlog

--- a/alpine/5/Dockerfile
+++ b/alpine/5/Dockerfile
@@ -111,7 +111,7 @@ RUN --mount=target=/var/www/app/node_modules,type=cache \
 	&& mv /var/www/app/storage $BAK_STORAGE_PATH \
 	&& mv /var/www/app/public $BAK_PUBLIC_PATH
 
-FROM phpbuild as prodbuild
+FROM phpbuild as prod
 
 COPY --from=dependencybuild --chown=$INVOICENINJA_USER:$INVOICENINJA_USER /var/www/app /var/www/app
 

--- a/alpine/5/Dockerfile
+++ b/alpine/5/Dockerfile
@@ -3,7 +3,7 @@ ARG BAK_STORAGE_PATH=/var/www/app/docker-backup-storage/
 ARG BAK_PUBLIC_PATH=/var/www/app/docker-backup-public/
 
 # Get Invoice Ninja and install nodejs packages
-FROM --platform=$BUILDPLATFORM node:lts-alpine as build
+FROM --platform=$BUILDPLATFORM node:lts-alpine as nodebuild
 
 # Download Invoice Ninja
 ARG INVOICENINJA_VERSION
@@ -30,9 +30,7 @@ RUN cp -r dist/tinymce_6.4.2/* /var/www/app/public/tinymce_6.4.2/
 # Download and extract the latest react application
 # 
 # Prepare php image
-FROM php:${PHP_VERSION}-fpm-alpine as prod
-
-COPY --from=build / /
+FROM php:${PHP_VERSION}-fpm-alpine as phpbuild
 
 LABEL maintainer="David Bomba <turbo124@gmail.com>"
 
@@ -90,7 +88,7 @@ ARG BAK_PUBLIC_PATH
 ENV INVOICENINJA_VERSION $INVOICENINJA_VERSION
 ENV BAK_STORAGE_PATH $BAK_STORAGE_PATH
 ENV BAK_PUBLIC_PATH $BAK_PUBLIC_PATH
-COPY --from=build --chown=$INVOICENINJA_USER:$INVOICENINJA_USER /var/www/app /var/www/app
+COPY --from=nodebuild --chown=$INVOICENINJA_USER:$INVOICENINJA_USER /var/www/app /var/www/app
 
 USER $UID
 WORKDIR /var/www/app
@@ -98,7 +96,24 @@ WORKDIR /var/www/app
 # Do not remove this ENV
 ENV IS_DOCKER true
 RUN /usr/local/bin/composer install --no-dev --no-scripts --no-interaction 
-RUN /usr/local/bin/composer dump-autoload --optimize --no-dev --classmap-authoritative --no-scripts --no-interaction 
+RUN /usr/local/bin/composer dump-autoload --optimize --no-dev --classmap-authoritative --no-scripts --no-interaction
+
+FROM --platform=$BUILDPLATFORM nodebuild AS dependencybuild
+
+COPY --from=phpbuild /var/www/app/vendor /var/www/app/vendor
+
+# Install node packages
+ARG BAK_STORAGE_PATH
+ARG BAK_PUBLIC_PATH
+RUN --mount=target=/var/www/app/node_modules,type=cache \
+	npm install \
+	&& npm run production \
+	&& mv /var/www/app/storage $BAK_STORAGE_PATH \
+	&& mv /var/www/app/public $BAK_PUBLIC_PATH
+
+FROM phpbuild as prodbuild
+
+COPY --from=dependencybuild --chown=$INVOICENINJA_USER:$INVOICENINJA_USER /var/www/app /var/www/app
 
 WORKDIR /var/www/app/
 

--- a/alpine/5/Dockerfile
+++ b/alpine/5/Dockerfile
@@ -100,6 +100,8 @@ RUN /usr/local/bin/composer dump-autoload --optimize --no-dev --classmap-authori
 
 FROM --platform=$BUILDPLATFORM nodebuild AS dependencybuild
 
+WORKDIR /var/www/app
+
 COPY --from=phpbuild /var/www/app/vendor /var/www/app/vendor
 
 # Install node packages


### PR DESCRIPTION
Due to the circular dependency of `livewire` JS module from composer, without intermediate build stages, the Docker build fails during the `vite` build step due to missing `livewire` module.

The changes here allow `composer install` to run then copies the vendor folder to an intermediate stage in order to complete the `vite` build with the `livewire` dependency being present.

Then the contents are copied back in another intermediate stage to the php environment to complete the build.