### PR TITLE
Specified compatible nginx version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.7'
 
 services:
   server:
-    image: nginx
+    image: nginx:1.25
     restart: always
     env_file: env
     volumes:


### PR DESCRIPTION
The nginx configuration used by Invoice Ninja is not compatible with the latest nginx Docker image. Changing docker-compose.yml to lock nginx to v1.25 which is known to work.