### PR TITLE
move client_max_body_size from default.conf to nginx.conf

### DIFF
--- a/debian/docker-compose.yml
+++ b/debian/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       resources:
         limits:
           memory: 512M
-          #memory: 1G # prevents swapping on pdf generation with chrome
     logging: *default-logging
 
   nginx:

--- a/debian/docker-compose.yml
+++ b/debian/docker-compose.yml
@@ -31,6 +31,7 @@ services:
       resources:
         limits:
           memory: 512M
+          #memory: 1G # prevents swapping on pdf generation with chrome
     logging: *default-logging
 
   nginx:

--- a/debian/nginx/conf.d/default.conf
+++ b/debian/nginx/conf.d/default.conf
@@ -8,8 +8,6 @@ server {
     
     server_tokens off;
     
-    client_max_body_size 100M;
-
     root /var/www/html/public;
     index index.php;
 

--- a/debian/nginx/nginx.conf
+++ b/debian/nginx/nginx.conf
@@ -22,5 +22,8 @@ http {
     keepalive_timeout 65;
     gzip on;
 
+    client_max_body_size 100M;
+    client_body_buffer_size 100M;
+
     include /etc/nginx/conf.d/*.conf;
 }


### PR DESCRIPTION
- [Module ngx_http_core_module](https://nginx.org/en/docs/http/ngx_http_core_module.html#client_max_body_size)
- add `client_body_buffer_size`
- prevents the following logs for each upload : `[warn] a client request body is buffered to a temporary file`