### PR TITLE
move google-chrome-stable related packages to arm64 section

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -5,36 +5,17 @@ ARG saxon=12.5.0
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl \
+    default-mysql-client \
     gnupg2 \
     gosu \
     supervisor \
-    default-mysql-client \
-    fonts-liberation \
     fonts-noto-cjk \
     fonts-noto-cjk-extra \
     fonts-wqy-microhei \
     fonts-wqy-zenhei \
-    libasound2 \
-    libatk-bridge2.0-0 \
-    libatk1.0-0 \
-    libatspi2.0-0 \
-    libcups2 \
-    libdbus-1-3 \
-    libdrm2 \
-    libgbm1 \
-    libgtk-3-0 \
-    libnspr4 \
-    libnss3 \
     libonig-dev \
     libpng-dev \
-    libwayland-client0 \
-    libxcomposite1 \
-    libxdamage1 \
-    libxfixes3 \
-    libxkbcommon0 \
     libxml2-dev \
-    libxrandr2 \
-    xdg-utils \
     xfonts-wqy \
     && if [ "$(dpkg --print-architecture)" = "amd64" ]; then \
         mkdir -p /etc/apt/keyrings \
@@ -42,6 +23,28 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends google-chrome-stable; \
+    fi \
+    && if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+        apt-get install -y --no-install-recommends \
+            fonts-liberation \
+            libasound2 \
+            libatk-bridge2.0-0 \
+            libatk1.0-0 \
+            libatspi2.0-0 \
+            libcups2 \
+            libdbus-1-3 \
+            libdrm2 \
+            libgbm1 \
+            libgtk-3-0 \
+            libnspr4 \
+            libnss3 \
+            libwayland-client0 \
+            libxcomposite1 \
+            libxdamage1 \
+            libxfixes3 \
+            libxkbcommon0 \
+            libxrandr2 \
+            xdg-utils \
     fi \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
@@ -118,10 +121,6 @@ COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Add initialization script
 COPY --chmod=0755 scripts/init.sh /usr/local/bin/init.sh
-
-# Configure PHP-FPM
-RUN sed -i "s/user = www-data/user = www-data/g" /usr/local/etc/php-fpm.d/www.conf \
-    && sed -i "s/group = www-data/group = www-data/g" /usr/local/etc/php-fpm.d/www.conf
 
 # Create volume directories
 RUN mkdir -p \

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg2 \
     gosu \
     supervisor \
+    # Packages to be checked
     fonts-noto-cjk \
     fonts-noto-cjk-extra \
     fonts-wqy-microhei \
@@ -23,9 +24,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
         && apt-get update \
         && apt-get install -y --no-install-recommends google-chrome-stable; \
-    fi \
-    && if [ "$(dpkg --print-architecture)" = "arm64" ]; then \
+    elif [ "$(dpkg --print-architecture)" = "arm64" ]; then \
         apt-get install -y --no-install-recommends \
+            # Packages for chrome
             fonts-liberation \
             libasound2 \
             libatk-bridge2.0-0 \
@@ -44,7 +45,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
             libxfixes3 \
             libxkbcommon0 \
             libxrandr2 \
-            xdg-utils \
+            xdg-utils; \
     fi \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/debian/docker-compose.yml
+++ b/debian/docker-compose.yml
@@ -59,16 +59,7 @@ services:
     networks:
       - app-network
     healthcheck:
-      test:
-        [
-          "CMD",
-          "mysqladmin",
-          "ping",
-          "-h",
-          "localhost",
-          "-u${MYSQL_USER}",
-          "-p${MYSQL_PASSWORD}",
-        ]
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost", "-u${MYSQL_USER}", "-p${MYSQL_PASSWORD}" ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -82,7 +73,7 @@ services:
     networks:
       - app-network
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: [ "CMD", "redis-cli", "ping" ]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/debian/php/php-fpm.conf
+++ b/debian/php/php-fpm.conf
@@ -1,2 +1,1 @@
-[www]
 pm.max_children = 10

--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 set -e
 
-
 in_log() {
-        local type="$1"; shift
-        printf '%s [%s] [Entrypoint]: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$type" "$*"
+    local type="$1"
+    shift
+    printf '%s [%s] [Entrypoint]: %s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$type" "$*"
 }
 
 docker_process_init_files() {
@@ -48,7 +48,6 @@ chown -R www-data:www-data /var/www/html/storage
 
 # Clear and cache config in production
 if [ "$APP_ENV" = "production" ]; then
-    gosu www-data php artisan config:cache
     gosu www-data php artisan optimize
     gosu www-data php artisan package:discover
     gosu www-data php artisan migrate --force


### PR DESCRIPTION
https://github.com/invoiceninja/dockerfiles/issues/660#issuecomment-2507312764

Remove unnecessary `php artisan config:cache` from `init.sh`, as it is handled with `php artisan optimize`

