### PR TITLE
Remove nginx `[warn]` log when uploading

### DIFF
--- a/debian/nginx/invoiceninja.conf
+++ b/debian/nginx/invoiceninja.conf
@@ -1,5 +1,6 @@
 # https://nginx.org/en/docs/http/ngx_http_core_module.html
 client_max_body_size 10M;
+client_body_buffer_size 10M;
 server_tokens off;
 
 # https://nginx.org/en/docs/http/ngx_http_fastcgi_module.html


### PR DESCRIPTION
- `[warn] a client request body is buffered to a temporary file`
- Was already fixed with commit bfc61fb64e095e24d1530e0aa9480d1597baff56
- Then got reverted by commit 66408fccb20b870bbf9f4510a4342e4de31e91a7