### PR TITLE
Fix for reap logging

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -68,7 +68,7 @@ COPY php/php.ini /usr/local/etc/php/conf.d/invoiceninja.ini
 
 COPY php/php-fpm.conf /usr/local/etc/php-fpm.d/invoiceninja.conf
 
-# Setup supervisor --chown=www-data:www-data
+# Setup supervisor
 COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 
 # Setup InvoiceNinja
@@ -80,7 +80,7 @@ COPY --chmod=0755 scripts/init.sh /usr/local/bin/init.sh
 
 # Health check
 HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
-    CMD php -v || exit 1
+    CMD pgrep -f "php-fpm: master process"
 
 ENTRYPOINT ["/usr/local/bin/init.sh"]
 CMD ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/debian/supervisor/supervisord.conf
+++ b/debian/supervisor/supervisord.conf
@@ -1,18 +1,12 @@
-[unix_http_server]
-file=/var/run/supervisor.sock
-chmod=0700
-
 [supervisord]
 nodaemon=true
 user=root
-logfile=/var/log/supervisor/supervisord.log
+logfile=/dev/stdout
+logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
 [rpcinterface:supervisor]
 supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
-
-[supervisorctl]
-serverurl=unix:///var/run/supervisor.sock
 
 [program:php-fpm]
 command=/usr/local/sbin/php-fpm -F
@@ -26,7 +20,7 @@ stderr_logfile_maxbytes=0
 
 [program:queue-worker]
 process_name=%(program_name)s_%(process_num)02d
-command=php /var/www/html/artisan queue:work --sleep=3 --tries=3 --max-time=3600
+command=php /var/www/html/artisan queue:work --sleep=3 --tries=3 --max-time=3600 --verbose
 autostart=true
 autorestart=true
 stopasgroup=true
@@ -41,7 +35,7 @@ stderr_logfile_maxbytes=0
 stopwaitsecs=3600
 
 [program:scheduler]
-command=php /var/www/html/artisan schedule:work --verbose --no-interaction
+command=php /var/www/html/artisan schedule:work --verbose
 autostart=true
 autorestart=true
 user=www-data

--- a/debian/supervisor/supervisord.conf
+++ b/debian/supervisor/supervisord.conf
@@ -1,7 +1,7 @@
 [supervisord]
 nodaemon=true
 user=root
-logfile=/dev/stdout
+logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
@@ -13,10 +13,9 @@ command=/usr/local/sbin/php-fpm -F
 autostart=true
 autorestart=true
 priority=5
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:queue-worker]
 process_name=%(program_name)s_%(process_num)02d
@@ -28,10 +27,9 @@ killasgroup=true
 user=www-data
 numprocs=2
 environment=HOME="/var/www"
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true
 stopwaitsecs=3600
 
 [program:scheduler]
@@ -39,7 +37,6 @@ command=php /var/www/html/artisan schedule:work --verbose
 autostart=true
 autorestart=true
 user=www-data
-stdout_logfile=/dev/stdout
+stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
-stderr_logfile=/dev/stderr
-stderr_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
Based on https://docs.docker.com/engine/containers/multi-service_container/#use-a-process-manager, we need to redirect logs for supervisord to logfile=/dev/null.