### PR TITLE
google-chrome-stable does not exist, replace with chromium

### DIFF
--- a/debian/.env
+++ b/debian/.env
@@ -57,6 +57,4 @@ NORDIGEN_SECRET_KEY=
 
 IS_DOCKER=true
 SCOUT_DRIVER=null
-SNAPPDF_CHROMIUM_PATH=/usr/bin/google-chrome-stable
-
-
+SNAPPDF_CHROMIUM_PATH=/usr/bin/chromium


### PR DESCRIPTION
I saw a reference to Google Chrome stable being installed in the dockerfile, but ultimately the only binary that’s showed up in my fresh installs in /usr/bin/chromium.

I was getting 500s when attempting to generate PDFs. After changing this and restarting, I now see PDF previews.

If this PR gets treated as an issue and there’s a way better/different fix, that’s cool too.