### PR TITLE
Create required dirs if missing

### DIFF
--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -1,6 +1,12 @@
 #!/bin/sh -eu
 
 if [ "$*" = 'supervisord -c /etc/supervisor/conf.d/supervisord.conf' ]; then
+
+    # Check for required folders and create if needed
+    [ -d /var/www/html/storage/framework/sessions ] || mkdir -p /var/www/html/storage/framework/sessions
+    [ -d /var/www/html/storage/framework/views ] || mkdir -p /var/www/html/storage/framework/views
+    [ -d /var/www/html/storage/framework/cache ] || mkdir -p /var/www/html/storage/framework/cache
+
     # Workaround for application updates
     if [ "$(ls -A /tmp/public)" ]; then
         echo "Updating public folder..."


### PR DESCRIPTION
If setting up the docker image from scratch, there currently is an error regarding the cache folder, following the answer in this thread, the fix is to manually create these folders https://stackoverflow.com/a/39179261