### PR TITLE
fix: update init script to chown cache directory

### DIFF
--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -17,12 +17,15 @@ if [ "$*" = 'supervisord -c /etc/supervisor/conf.d/supervisord.conf' ]; then
     # Ensure owner, file and directory permissions are correct
     chown -R www-data:www-data \
         /var/www/html/public \
-        /var/www/html/storage
+        /var/www/html/storage \
+        /var/www/html/bootstrap/cache
     find /var/www/html/public \
         /var/www/html/storage \
+        /var/www/html/bootstrap/cache \
         -type f -exec chmod 644 {} \;
     find /var/www/html/public \
         /var/www/html/storage \
+        /var/www/html/bootstrap/cache \
         -type d -exec chmod 755 {} \;
 
     # Clear and cache config in production


### PR DESCRIPTION
Using provided docker-compose file, IN does not start up due to invalid directory permissions, cycling the error message:

```
Updating public folder...
Public Folder is up to date
In PackageManifest.php line 179:
                                                                             
  The /var/www/html/bootstrap/cache directory must be present and writable. 
```

This PR chown's the bootstrap/cache directory that's mounted into the container fixing this issue similar to all the other mounted volumes.