### PR TITLE
Fixes #743: Move conditionals for chromium/google chrome at the top of the file

### DIFF
--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -1,5 +1,12 @@
 #!/bin/sh -eu
 
+# Set PDF generation browser path based on architecture
+if [ "$(dpkg --print-architecture)" = "amd64" ]; then
+    export SNAPPDF_CHROMIUM_PATH=/usr/bin/google-chrome-stable
+elif [ "$(dpkg --print-architecture)" = "arm64" ]; then
+    export SNAPPDF_CHROMIUM_PATH=/usr/bin/chromium
+fi
+
 if [ "$*" = 'supervisord -c /etc/supervisor/conf.d/supervisord.conf' ]; then
 
     # Check for required folders and create if needed
@@ -55,13 +62,6 @@ if [ "$*" = 'supervisord -c /etc/supervisor/conf.d/supervisord.conf' ]; then
     fi
 
     echo "Starting supervisord..."
-fi
-
-# Set PDF generation browser path based on architecture
-if [ "$(dpkg --print-architecture)" = "amd64" ]; then
-    export SNAPPDF_CHROMIUM_PATH=/usr/bin/google-chrome-stable
-elif [ "$(dpkg --print-architecture)" = "arm64" ]; then
-    export SNAPPDF_CHROMIUM_PATH=/usr/bin/chromium
 fi
 
 exec "$@"


### PR DESCRIPTION
Enables the conditional setting of `SNAPPDF_CHROMIUM_PATH`, allowing the removal of the variables in the `.env` file.

Having it at the bottom of the file prevents it to be effectively set.