### PR TITLE
Use default supervisord config as baseline

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -41,7 +41,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && apt-get install -y --no-install-recommends google-chrome-stable; \
     elif [ "$(dpkg --print-architecture)" = "arm64" ]; then \
     apt-get install -y --no-install-recommends \
-    chromium; \        
+    chromium; \
     fi \
     # Create config directory for chromium/google-chrome-stable
     && mkdir /var/www/.config \
@@ -82,4 +82,4 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 \
     CMD pgrep -f "php-fpm: master process"
 
 ENTRYPOINT ["/usr/local/bin/init.sh"]
-CMD ["supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]
+CMD ["supervisord", "-c", "/etc/supervisor/supervisord.conf"]

--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -7,7 +7,7 @@ elif [ "$(dpkg --print-architecture)" = "arm64" ]; then
     export SNAPPDF_CHROMIUM_PATH=/usr/bin/chromium
 fi
 
-if [ "$*" = 'supervisord -c /etc/supervisor/conf.d/supervisord.conf' ]; then
+if [ "$*" = 'supervisord -c /etc/supervisor/supervisord.conf' ]; then
 
     # Check for required folders and create if needed
     [ -d /var/www/html/storage/framework/sessions ] || mkdir -p /var/www/html/storage/framework/sessions

--- a/debian/supervisor/supervisord.conf
+++ b/debian/supervisor/supervisord.conf
@@ -5,9 +5,6 @@ logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
-[rpcinterface:supervisor]
-supervisor.rpcinterface_factory=supervisor.rpcinterface:make_main_rpcinterface
-
 [program:php-fpm]
 command=/usr/local/sbin/php-fpm -F
 autostart=true


### PR DESCRIPTION
Start supervisord using /etc/supervisor/supervisord.conf so that a socket at /var/run is created (default supervisord config). This fixes the error message when trying to use supervisorctl inside the container.

Problem: In the current setup, supervisor is started with /etc/supervisor/conf.d/supervisord.conf, this ignores all default settings in /etc/supervisor/supervisord.conf (like the socket creation at /var/run, such that supervisorctl is able to access supervisor).

It is not needed to start supervisor with /etc/supervisor/conf.d/supervisord.conf instead of /etc/supervisor/supervisord.conf because the default config will load all configs at conf.d/*.conf