### PR TITLE
Update php.ini to disable opcache in cli

### DIFF
--- a/debian/php/php.ini
+++ b/debian/php/php.ini
@@ -5,7 +5,7 @@ upload_max_filesize=10M
 
 [opcache]
 ; https://www.php.net/manual/en/opcache.installation.php#opcache.installation.recommended
-opcache.enable_cli=1
+opcache.enable_cli=0
 
 [jit]
 ; https://wiki.php.net/rfc/jit_config_defaults


### PR DESCRIPTION
using `opcache.preload=/var/www/html/preload.php` and `opcache.enable_cli=1` together in php.ini is incompatible with composer and causes `composer` to throw error messages regarding the inclusion of wrong vendor/symfony files.

https://github.com/invoiceninja/dockerfiles/issues/780 https://github.com/composer/composer/issues/12514