### PR TITLE
Workaround: Disable SSL for mariadb-client for compatibility with MySQL

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -68,6 +68,9 @@ COPY php/php.ini /usr/local/etc/php/conf.d/invoiceninja.ini
 
 COPY php/php-fpm.conf /usr/local/etc/php-fpm.d/invoiceninja.conf
 
+# Workaround: Disable SSL for mariadb-client for compatibility with MySQL
+RUN echo "skip-ssl = true" >> /etc/mysql/mariadb.conf.d/50-client.cnf
+
 # Setup supervisor
 COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 

--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -38,10 +38,6 @@ if [ "$*" = 'supervisord -c /etc/supervisor/supervisord.conf' ]; then
         /var/www/html/storage \
         -type d -exec chmod 755 {} \;
 
-    # Fix mariadb-client connection to mysql
-    echo "[client]\nskip-ssl = true" > /var/www/.my.cnf
-    chown www-data:www-data /var/www/.my.cnf    
-
     # Clear and cache config in production
     if [ "$APP_ENV" = "production" ]; then
         runuser -u www-data -- php artisan optimize


### PR DESCRIPTION
Disable ssl in Dockerfile instead of init.sh, to align with octane