### PR TITLE
Roll back to PHP 8.3

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -1,4 +1,4 @@
-ARG PHP=8.4
+ARG PHP=8.3
 
 FROM php:${PHP}-fpm AS prepare-app
 


### PR DESCRIPTION
@benbrummer rolling back to 8.3, I think the autoloader was having issues because we built the .tar file with PHP 8.2, and the container was running 8.4 which I *think* broke the autoloader.