### PR TITLE
Compose file refactoring - Debian

### DIFF
--- a/debian/docker-compose.yml
+++ b/debian/docker-compose.yml
@@ -52,9 +52,6 @@ services:
           "-u${MYSQL_USER}",
           "-p${MYSQL_PASSWORD}",
         ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
   redis:
     image: redis:alpine
@@ -63,9 +60,6 @@ services:
       - redis_data:/data
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
-      interval: 10s
-      timeout: 5s
-      retries: 5
 
 volumes:
   app_public:


### PR DESCRIPTION
* .env file was passing all (secrets) to mysql
* .env file volume and env_file: where used redundantly => volume was removed
* docker logging extension has been removed. docker by default will rotate and most logs are logged to laravel.log
* healthcheck timing has been removed. Default timings https://docs.docker.com/reference/dockerfile/#healthcheck are sufficient. For invoiceninja a specific timing is configured in dockerfile.