### PR TITLE
Correct minor version formatting in publish-image.yaml

### DIFF
--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -127,7 +127,7 @@ jobs:
           tags: |
             ${{ needs.version.outputs.version }}
             ${{ needs.version.outputs.major }}
-            ${{ needs.version.outputs.major }}${{ needs.version.outputs.minor }}
+            ${{ needs.version.outputs.major }}.${{ needs.version.outputs.minor }}
             latest
 
       - name: Create manifest list and push


### PR DESCRIPTION
Last workflows have been executet with wrong version tag 5.11.28-d3 instead of 5.12.28-d3 => 511 contains 5.12.28-d3

Fix: major minor tag has missing a separator