### PR TITLE
Update Dockerfile to use ADD for downloading files, instead of RUN curl

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -2,13 +2,11 @@ ARG PHP=8.4
 
 FROM php:${PHP}-fpm AS prepare-app
 
-# ADD is always executed as root, so we use --chown
-ADD --chown=www-data:www-data https://github.com/invoiceninja/invoiceninja/releases/latest/download/invoiceninja.tar.gz /tmp/invoiceninja.tar.gz
+ADD https://github.com/invoiceninja/invoiceninja/releases/latest/download/invoiceninja.tar.gz /tmp/invoiceninja.tar.gz
 
 USER www-data
 
 RUN tar -xzf /tmp/invoiceninja.tar.gz -C /var/www/html \
-    && rm /tmp/invoiceninja.tar.gz \
     && ln -s /var/www/html/resources/views/react/index.blade.php /var/www/html/public/index.html \
     && php artisan storage:link \
     # Workaround for application updates


### PR DESCRIPTION
Replaced curl command with `ADD` instruction for downloading Invoice Ninja instead of RUN curl.
This improves the caching ability of Docker.

The `RUN` instruction will not invalidate the cache unless its text changes. So if the remote file is updated, you won't get it. Docker will use the cached layer.

The `ADD` instruction will always download the file and the cache will be invalidated if the checksum of the file no longer matches.
