### PR TITLE
Change mv to cp for public folder update

### DIFF
--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -25,7 +25,7 @@ if [ "$*" = 'supervisord -c /etc/supervisor/supervisord.conf' ]; then
             /tmp/public/.htaccess \
             /tmp/public/.well-known \
             /var/www/html/public/ && \
-            rm -rf /tmp/public/
+            rm -rf /tmp/public/*
     fi
     echo "Public Folder is up to date"
 


### PR DESCRIPTION
Replaced mv command with cp for copying files to public folder and added cleanup of temporary public files. This is a robust alternative to mv for e.g ZFS and docker overlay2

Closes https://github.com/invoiceninja/dockerfiles/issues/840