### PR TITLE
Add a helm chart for K8S

### DIFF
--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: invoiceninja
+description: Helm chart for Invoice Ninja Debian stack (app, nginx, mysql, redis)
+type: application
+version: 0.1.0
+appVersion: "latest"

--- a/charts/invoiceninja/Chart.yaml
+++ b/charts/invoiceninja/Chart.yaml
@@ -3,4 +3,6 @@ name: invoiceninja
 description: Helm chart for Invoice Ninja Debian stack (app, nginx, mysql, redis)
 type: application
 version: 0.1.0
-appVersion: "latest"
+appVersion: "5"
+maintainers:
+  - name: eburgueno

--- a/charts/invoiceninja/README.md
+++ b/charts/invoiceninja/README.md
@@ -1,0 +1,46 @@
+# Invoice Ninja Helm Chart
+
+This chart deploys the Debian Invoice Ninja stack based on `debian/docker-compose.yml`:
+- `app` (php-fpm + supervisor)
+- `nginx`
+- `mysql`
+- `redis`
+
+## Install
+
+```bash
+helm install invoiceninja ./charts/invoiceninja \
+  -n invoiceninja \
+  --create-namespace \
+  --set secret.appKey='base64:YOUR_APP_KEY' \
+  --set env.appUrl='http://invoiceninja.local'
+```
+
+## Upgrade
+
+```bash
+helm upgrade invoiceninja ./charts/invoiceninja \
+  -n invoiceninja \
+  --set secret.appKey='base64:YOUR_APP_KEY' \
+  --set env.appUrl='http://invoiceninja.local'
+```
+
+## Access
+
+```bash
+kubectl -n invoiceninja port-forward svc/invoiceninja-nginx 8080:80
+```
+
+Open http://127.0.0.1:8080
+
+## Persistence
+
+Persistence is disabled by default so the chart works on clusters without a default StorageClass.
+
+To enable persistence, set:
+- `persistence.appPublic.enabled=true`
+- `persistence.appStorage.enabled=true`
+- `persistence.mysqlData.enabled=true`
+- `persistence.redisData.enabled=true`
+
+Optionally set `storageClassName` for each claim.

--- a/charts/invoiceninja/templates/_helpers.tpl
+++ b/charts/invoiceninja/templates/_helpers.tpl
@@ -1,0 +1,45 @@
+{{- define "invoiceninja.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "invoiceninja.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "invoiceninja.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "invoiceninja.labels" -}}
+helm.sh/chart: {{ include "invoiceninja.chart" . }}
+app.kubernetes.io/name: {{ include "invoiceninja.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "invoiceninja.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "invoiceninja.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "invoiceninja.appServiceName" -}}
+{{- printf "%s-app" (include "invoiceninja.fullname" .) -}}
+{{- end -}}
+
+{{- define "invoiceninja.mysqlServiceName" -}}
+{{- printf "%s-mysql" (include "invoiceninja.fullname" .) -}}
+{{- end -}}
+
+{{- define "invoiceninja.redisServiceName" -}}
+{{- printf "%s-redis" (include "invoiceninja.fullname" .) -}}
+{{- end -}}

--- a/charts/invoiceninja/templates/app.yaml
+++ b/charts/invoiceninja/templates/app.yaml
@@ -1,0 +1,125 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "invoiceninja.appServiceName" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  replicas: {{ .Values.app.replicaCount }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  selector:
+    matchLabels:
+      {{- include "invoiceninja.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: app
+  template:
+    metadata:
+      labels:
+        {{- include "invoiceninja.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: app
+    spec:
+      securityContext:
+        {{- toYaml .Values.app.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: wait-dependencies
+          image: busybox:1.36
+          imagePullPolicy: IfNotPresent
+          securityContext:
+            {{- toYaml .Values.app.securityContext | nindent 12 }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              until nc -z {{ include "invoiceninja.mysqlServiceName" . }} {{ .Values.mysql.service.port }}; do
+                echo "waiting for mysql";
+                sleep 2;
+              done
+              until nc -z {{ include "invoiceninja.redisServiceName" . }} {{ .Values.redis.service.port }}; do
+                echo "waiting for redis";
+                sleep 2;
+              done
+      containers:
+        - name: app
+          image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}"
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          ports:
+            - name: fpm
+              containerPort: 9000
+              protocol: TCP
+          envFrom:
+            - configMapRef:
+                name: {{ include "invoiceninja.fullname" . }}-config
+            - secretRef:
+                name: {{ include "invoiceninja.fullname" . }}-secret
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'REMOTE_ADDR=127.0.0.1 REQUEST_URI=/health REQUEST_METHOD=GET SCRIPT_FILENAME=/var/www/html/public/index.php cgi-fcgi -bind -connect 127.0.0.1:9000 | grep -q "{\"status\":\"ok\",\"message\":\"API is healthy\"}"'
+            initialDelaySeconds: 120
+            timeoutSeconds: 10
+            periodSeconds: 30
+            failureThreshold: 5
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'REMOTE_ADDR=127.0.0.1 REQUEST_URI=/health REQUEST_METHOD=GET SCRIPT_FILENAME=/var/www/html/public/index.php cgi-fcgi -bind -connect 127.0.0.1:9000 | grep -q "{\"status\":\"ok\",\"message\":\"API is healthy\"}"'
+            initialDelaySeconds: 40
+            timeoutSeconds: 10
+            periodSeconds: 20
+            failureThreshold: 6
+          resources:
+            {{- toYaml .Values.app.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.app.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: app-public
+              mountPath: /var/www/html/public
+            - name: app-storage
+              mountPath: /var/www/html/storage
+      volumes:
+        - name: app-public
+          {{- if .Values.persistence.appPublic.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "invoiceninja.fullname" . }}-app-public
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: app-storage
+          {{- if .Values.persistence.appStorage.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "invoiceninja.fullname" . }}-app-storage
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "invoiceninja.appServiceName" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: app
+spec:
+  type: ClusterIP
+  ports:
+    - name: fpm
+      port: 9000
+      targetPort: fpm
+      protocol: TCP
+  selector:
+    {{- include "invoiceninja.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: app

--- a/charts/invoiceninja/templates/app.yaml
+++ b/charts/invoiceninja/templates/app.yaml
@@ -26,7 +26,7 @@ spec:
         {{- toYaml .Values.app.podSecurityContext | nindent 8 }}
       initContainers:
         - name: wait-dependencies
-          image: busybox:1.36
+          image: "busybox:{{ .Values.app.busyboxTag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
             {{- toYaml .Values.app.securityContext | nindent 12 }}
@@ -53,8 +53,32 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ include "invoiceninja.fullname" . }}-config
-            - secretRef:
-                name: {{ include "invoiceninja.fullname" . }}-secret
+          env:
+            - name: APP_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: APP_KEY
+            - name: DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: DB_PASSWORD
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: REDIS_PASSWORD
+            - name: IN_USER_EMAIL
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: IN_USER_EMAIL
+            - name: IN_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: IN_PASSWORD
           livenessProbe:
             exec:
               command:

--- a/charts/invoiceninja/templates/app.yaml
+++ b/charts/invoiceninja/templates/app.yaml
@@ -29,7 +29,7 @@ spec:
           image: "busybox:{{ .Values.app.busyboxTag }}"
           imagePullPolicy: IfNotPresent
           securityContext:
-            {{- toYaml .Values.app.securityContext | nindent 12 }}
+            {{- toYaml .Values.app.initSecurityContext | nindent 12 }}
           command:
             - /bin/sh
             - -c

--- a/charts/invoiceninja/templates/configmap.yaml
+++ b/charts/invoiceninja/templates/configmap.yaml
@@ -1,0 +1,88 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-config
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+data:
+  APP_URL: {{ .Values.env.appUrl | quote }}
+  APP_ENV: {{ .Values.env.appEnv | quote }}
+  APP_DEBUG: {{ .Values.env.appDebug | quote }}
+  REQUIRE_HTTPS: {{ .Values.env.requireHttps | quote }}
+  PHANTOMJS_PDF_GENERATION: {{ .Values.env.phantomjsPdfGeneration | quote }}
+  PDF_GENERATOR: {{ .Values.env.pdfGenerator | quote }}
+  TRUSTED_PROXIES: {{ .Values.env.trustedProxies | quote }}
+  CACHE_DRIVER: {{ .Values.env.cacheDriver | quote }}
+  QUEUE_CONNECTION: {{ .Values.env.queueConnection | quote }}
+  SESSION_DRIVER: {{ .Values.env.sessionDriver | quote }}
+  REDIS_HOST: {{ include "invoiceninja.redisServiceName" . | quote }}
+  REDIS_PORT: {{ .Values.env.redisPort | quote }}
+  FILESYSTEM_DISK: {{ .Values.env.filesystemDisk | quote }}
+  DB_HOST: {{ include "invoiceninja.mysqlServiceName" . | quote }}
+  DB_PORT: {{ .Values.env.dbPort | quote }}
+  DB_DATABASE: {{ .Values.env.dbDatabase | quote }}
+  DB_USERNAME: {{ .Values.env.dbUsername | quote }}
+  DB_CONNECTION: {{ .Values.env.dbConnection | quote }}
+  MAIL_MAILER: {{ .Values.env.mailMailer | quote }}
+  MAIL_HOST: {{ .Values.env.mailHost | quote }}
+  MAIL_PORT: {{ .Values.env.mailPort | quote }}
+  MAIL_USERNAME: {{ .Values.env.mailUsername | quote }}
+  MAIL_PASSWORD: {{ .Values.env.mailPassword | quote }}
+  MAIL_ENCRYPTION: {{ .Values.env.mailEncryption | quote }}
+  MAIL_FROM_ADDRESS: {{ .Values.env.mailFromAddress | quote }}
+  MAIL_FROM_NAME: {{ .Values.env.mailFromName | quote }}
+  MYSQL_DATABASE: {{ .Values.env.mysqlDatabase | quote }}
+  MYSQL_USER: {{ .Values.env.mysqlUser | quote }}
+  NORDIGEN_SECRET_ID: {{ .Values.env.nordigenSecretId | quote }}
+  NORDIGEN_SECRET_KEY: {{ .Values.env.nordigenSecretKey | quote }}
+  IS_DOCKER: {{ .Values.env.isDocker | quote }}
+  SCOUT_DRIVER: {{ .Values.env.scoutDriver | quote }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-nginx
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+data:
+  invoiceninja.conf: |
+    client_max_body_size 10M;
+    client_body_buffer_size 10M;
+    server_tokens off;
+    fastcgi_buffers 32 16K;
+    gzip on;
+    gzip_comp_level 2;
+    gzip_min_length 1M;
+    gzip_proxied any;
+    gzip_types *;
+  laravel.conf: |
+    server {
+        listen 80 default_server;
+        server_name _;
+        root /var/www/html/public;
+
+        add_header X-Frame-Options "SAMEORIGIN";
+        add_header X-Content-Type-Options "nosniff";
+
+        index index.php;
+        charset utf-8;
+
+        location / {
+            try_files $uri $uri/ /index.php?$query_string;
+        }
+
+        location = /favicon.ico { access_log off; log_not_found off; }
+        location = /robots.txt  { access_log off; log_not_found off; }
+
+        error_page 404 /index.php;
+
+        location ~ \.php$ {
+            fastcgi_pass {{ include "invoiceninja.appServiceName" . }}:9000;
+            fastcgi_param SCRIPT_FILENAME $realpath_root$fastcgi_script_name;
+            include fastcgi_params;
+        }
+
+        location ~ /\.(?!well-known).* {
+            deny all;
+        }
+    }

--- a/charts/invoiceninja/templates/configmap.yaml
+++ b/charts/invoiceninja/templates/configmap.yaml
@@ -31,8 +31,8 @@ data:
   MAIL_ENCRYPTION: {{ .Values.env.mailEncryption | quote }}
   MAIL_FROM_ADDRESS: {{ .Values.env.mailFromAddress | quote }}
   MAIL_FROM_NAME: {{ .Values.env.mailFromName | quote }}
-  MYSQL_DATABASE: {{ .Values.env.mysqlDatabase | quote }}
-  MYSQL_USER: {{ .Values.env.mysqlUser | quote }}
+  MYSQL_DATABASE: {{ .Values.env.dbDatabase | quote }}
+  MYSQL_USER: {{ .Values.env.dbUsername | quote }}
   NORDIGEN_SECRET_ID: {{ .Values.env.nordigenSecretId | quote }}
   NORDIGEN_SECRET_KEY: {{ .Values.env.nordigenSecretKey | quote }}
   IS_DOCKER: {{ .Values.env.isDocker | quote }}
@@ -52,7 +52,7 @@ data:
     fastcgi_buffers 32 16K;
     gzip on;
     gzip_comp_level 2;
-    gzip_min_length 1M;
+    gzip_min_length 1000;
     gzip_proxied any;
     gzip_types *;
   laravel.conf: |

--- a/charts/invoiceninja/templates/configmap.yaml
+++ b/charts/invoiceninja/templates/configmap.yaml
@@ -57,7 +57,7 @@ data:
     gzip_types *;
   laravel.conf: |
     server {
-        listen 80 default_server;
+        listen {{ .Values.nginx.containerPort }} default_server;
         server_name _;
         root /var/www/html/public;
 

--- a/charts/invoiceninja/templates/ingress.yaml
+++ b/charts/invoiceninja/templates/ingress.yaml
@@ -1,0 +1,35 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "invoiceninja.fullname" $ }}-nginx
+                port:
+                  number: {{ $.Values.nginx.service.port }}
+          {{- end }}
+    {{- end }}
+  {{- with .Values.ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/invoiceninja/templates/mysql.yaml
+++ b/charts/invoiceninja/templates/mysql.yaml
@@ -1,0 +1,107 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "invoiceninja.mysqlServiceName" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "invoiceninja.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: mysql
+  template:
+    metadata:
+      labels:
+        {{- include "invoiceninja.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mysql
+    spec:
+      securityContext:
+        {{- toYaml .Values.mysql.podSecurityContext | nindent 8 }}
+      containers:
+        - name: mysql
+          image: "{{ .Values.mysql.image.repository }}:{{ .Values.mysql.image.tag }}"
+          imagePullPolicy: {{ .Values.mysql.image.pullPolicy }}
+          ports:
+            - name: mysql
+              containerPort: 3306
+              protocol: TCP
+          env:
+            - name: MYSQL_DATABASE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-config
+                  key: MYSQL_DATABASE
+            - name: MYSQL_USER
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-config
+                  key: MYSQL_USER
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: MYSQL_PASSWORD
+            - name: MYSQL_ROOT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: MYSQL_ROOT_PASSWORD
+          livenessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'mysqladmin ping -h localhost -u$MYSQL_USER -p$MYSQL_PASSWORD'
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - 'mysqladmin ping -h localhost -u$MYSQL_USER -p$MYSQL_PASSWORD'
+            initialDelaySeconds: 20
+            timeoutSeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.mysql.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.mysql.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: mysql-data
+              mountPath: /var/lib/mysql
+      volumes:
+        - name: mysql-data
+          {{- if .Values.persistence.mysqlData.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "invoiceninja.fullname" . }}-mysql-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      nodeSelector:
+        {{- toYaml .Values.mysql.nodeSelector | nindent 8 }}
+      affinity:
+        {{- toYaml .Values.mysql.affinity | nindent 8 }}
+      tolerations:
+        {{- toYaml .Values.mysql.tolerations | nindent 8 }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "invoiceninja.mysqlServiceName" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql
+spec:
+  type: ClusterIP
+  ports:
+    - name: mysql
+      port: {{ .Values.mysql.service.port }}
+      targetPort: mysql
+      protocol: TCP
+  selector:
+    {{- include "invoiceninja.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: mysql

--- a/charts/invoiceninja/templates/mysql.yaml
+++ b/charts/invoiceninja/templates/mysql.yaml
@@ -53,7 +53,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'mysqladmin ping -h localhost -u$MYSQL_USER -p$MYSQL_PASSWORD'
+                - 'mariadb-admin ping -h 127.0.0.1 -u$MYSQL_USER -p$MYSQL_PASSWORD'
             initialDelaySeconds: 30
             timeoutSeconds: 10
             periodSeconds: 20
@@ -62,7 +62,7 @@ spec:
               command:
                 - /bin/sh
                 - -c
-                - 'mysqladmin ping -h localhost -u$MYSQL_USER -p$MYSQL_PASSWORD'
+                - 'mariadb-admin ping -h 127.0.0.1 -u$MYSQL_USER -p$MYSQL_PASSWORD'
             initialDelaySeconds: 20
             timeoutSeconds: 10
             periodSeconds: 10

--- a/charts/invoiceninja/templates/namespace.yml
+++ b/charts/invoiceninja/templates/namespace.yml
@@ -1,0 +1,11 @@
+{{- if .Values.namespace.create }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Release.Namespace }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted
+{{- end }}

--- a/charts/invoiceninja/templates/nginx.yaml
+++ b/charts/invoiceninja/templates/nginx.yaml
@@ -1,0 +1,106 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-nginx
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  replicas: {{ .Values.nginx.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "invoiceninja.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: nginx
+  template:
+    metadata:
+      labels:
+        {{- include "invoiceninja.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: nginx
+    spec:
+      securityContext:
+        {{- toYaml .Values.nginx.podSecurityContext | nindent 8 }}
+      {{- if not .Values.persistence.appPublic.enabled }}
+      initContainers:
+        - name: seed-public-dir
+          image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}"
+          imagePullPolicy: {{ .Values.app.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.nginx.initSecurityContext | nindent 12 }}
+          command:
+            - /bin/sh
+            - -c
+            - |
+              mkdir -p /var/www/html/public
+              cp -r /tmp/public/. /var/www/html/public/ 2>/dev/null || true
+          volumeMounts:
+            - name: app-public
+              mountPath: /var/www/html/public
+      {{- end }}
+      containers:
+        - name: nginx
+          image: "{{ .Values.nginx.image.repository }}:{{ .Values.nginx.image.tag }}"
+          imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 80
+              protocol: TCP
+          livenessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 20
+            periodSeconds: 20
+          readinessProbe:
+            tcpSocket:
+              port: http
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.nginx.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.nginx.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: app-public
+              mountPath: /var/www/html/public
+              readOnly: true
+            - name: app-storage
+              mountPath: /var/www/html/storage
+              readOnly: true
+            - name: nginx-config
+              mountPath: /etc/nginx/conf.d
+              readOnly: true
+      volumes:
+        - name: app-public
+          {{- if .Values.persistence.appPublic.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "invoiceninja.fullname" . }}-app-public
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: app-storage
+          {{- if .Values.persistence.appStorage.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "invoiceninja.fullname" . }}-app-storage
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+        - name: nginx-config
+          configMap:
+            name: {{ include "invoiceninja.fullname" . }}-nginx
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-nginx
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx
+spec:
+  type: {{ .Values.nginx.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.nginx.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "invoiceninja.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: nginx

--- a/charts/invoiceninja/templates/nginx.yaml
+++ b/charts/invoiceninja/templates/nginx.yaml
@@ -42,7 +42,7 @@ spec:
           imagePullPolicy: {{ .Values.nginx.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 80
+              containerPort: {{ .Values.nginx.containerPort }}
               protocol: TCP
           livenessProbe:
             tcpSocket:

--- a/charts/invoiceninja/templates/pvc.yaml
+++ b/charts/invoiceninja/templates/pvc.yaml
@@ -1,0 +1,71 @@
+{{- if .Values.persistence.appPublic.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-app-public
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.appPublic.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.appPublic.size }}
+  {{- if .Values.persistence.appPublic.storageClassName }}
+  storageClassName: {{ .Values.persistence.appPublic.storageClassName | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.persistence.appStorage.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-app-storage
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.appStorage.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.appStorage.size }}
+  {{- if .Values.persistence.appStorage.storageClassName }}
+  storageClassName: {{ .Values.persistence.appStorage.storageClassName | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.persistence.mysqlData.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-mysql-data
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.mysqlData.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.mysqlData.size }}
+  {{- if .Values.persistence.mysqlData.storageClassName }}
+  storageClassName: {{ .Values.persistence.mysqlData.storageClassName | quote }}
+  {{- end }}
+---
+{{- end }}
+{{- if .Values.persistence.redisData.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-redis-data
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    {{- toYaml .Values.persistence.redisData.accessModes | nindent 4 }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.redisData.size }}
+  {{- if .Values.persistence.redisData.storageClassName }}
+  storageClassName: {{ .Values.persistence.redisData.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/invoiceninja/templates/redis.yaml
+++ b/charts/invoiceninja/templates/redis.yaml
@@ -1,0 +1,76 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "invoiceninja.redisServiceName" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "invoiceninja.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: redis
+  template:
+    metadata:
+      labels:
+        {{- include "invoiceninja.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: redis
+    spec:
+      securityContext:
+        {{- toYaml .Values.redis.podSecurityContext | nindent 8 }}
+      containers:
+        - name: redis
+          image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
+          imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          ports:
+            - name: redis
+              containerPort: 6379
+              protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 10
+            periodSeconds: 20
+          readinessProbe:
+            exec:
+              command:
+                - redis-cli
+                - ping
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources:
+            {{- toYaml .Values.redis.resources | nindent 12 }}
+          securityContext:
+            {{- toYaml .Values.redis.securityContext | nindent 12 }}
+          volumeMounts:
+            - name: redis-data
+              mountPath: /data
+      volumes:
+        - name: redis-data
+          {{- if .Values.persistence.redisData.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ include "invoiceninja.fullname" . }}-redis-data
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "invoiceninja.redisServiceName" . }}
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+    app.kubernetes.io/component: redis
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: {{ .Values.redis.service.port }}
+      targetPort: redis
+      protocol: TCP
+  selector:
+    {{- include "invoiceninja.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: redis

--- a/charts/invoiceninja/templates/redis.yaml
+++ b/charts/invoiceninja/templates/redis.yaml
@@ -23,6 +23,18 @@ spec:
         - name: redis
           image: "{{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}"
           imagePullPolicy: {{ .Values.redis.image.pullPolicy }}
+          {{- if .Values.secret.redisPassword }}
+          command:
+            - redis-server
+            - --requirepass
+            - $(REDISCLI_AUTH)
+          env:
+            - name: REDISCLI_AUTH
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  key: REDIS_PASSWORD
+          {{- end }}
           ports:
             - name: redis
               containerPort: 6379

--- a/charts/invoiceninja/templates/secret.yaml
+++ b/charts/invoiceninja/templates/secret.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "invoiceninja.fullname" . }}-secret
+  labels:
+    {{- include "invoiceninja.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  APP_KEY: {{ .Values.secret.appKey | quote }}
+  DB_PASSWORD: {{ .Values.secret.dbPassword | quote }}
+  DB_ROOT_PASSWORD: {{ .Values.secret.dbRootPassword | quote }}
+  MYSQL_PASSWORD: {{ .Values.secret.dbPassword | quote }}
+  MYSQL_ROOT_PASSWORD: {{ .Values.secret.dbRootPassword | quote }}
+  REDIS_PASSWORD: {{ .Values.secret.redisPassword | quote }}
+  IN_USER_EMAIL: {{ .Values.secret.inUserEmail | quote }}
+  IN_PASSWORD: {{ .Values.secret.inPassword | quote }}

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -1,0 +1,167 @@
+nameOverride: ""
+fullnameOverride: ""
+
+app:
+  image:
+    repository: invoiceninja/invoiceninja-debian
+    tag: latest
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  resources: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    readOnlyRootFilesystem: false
+    capabilities:
+      drop:
+        - ALL
+
+nginx:
+  image:
+    repository: nginx
+    tag: alpine
+    pullPolicy: IfNotPresent
+  replicaCount: 1
+  service:
+    type: ClusterIP
+    port: 80
+  resources: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      add:
+        - CHOWN
+      drop:
+        - ALL
+  initSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+mysql:
+  image:
+    repository: mysql
+    tag: "8"
+    pullPolicy: IfNotPresent
+  service:
+    port: 3306
+  resources: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: true
+    capabilities:
+      drop:
+        - NET_RAW
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+redis:
+  image:
+    repository: redis
+    tag: alpine
+    pullPolicy: IfNotPresent
+  service:
+    port: 6379
+  resources: {}
+  podSecurityContext:
+    seccompProfile:
+      type: RuntimeDefault
+  securityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+
+persistence:
+  appPublic:
+    enabled: false
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+  appStorage:
+    enabled: false
+    accessModes:
+      - ReadWriteOnce
+    size: 5Gi
+    storageClassName: ""
+  mysqlData:
+    enabled: false
+    accessModes:
+      - ReadWriteOnce
+    size: 10Gi
+    storageClassName: ""
+  redisData:
+    enabled: false
+    accessModes:
+      - ReadWriteOnce
+    size: 1Gi
+    storageClassName: ""
+
+serviceAccount:
+  create: false
+  name: ""
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+  hosts:
+    - host: invoiceninja.local
+      paths:
+        - path: /
+          pathType: Prefix
+  tls: []
+
+secret:
+  appKey: ""
+  dbPassword: ninja
+  dbRootPassword: ninjaAdm1nPassword
+  redisPassword: ""
+  inUserEmail: admin@example.com
+  inPassword: changeme!
+
+env:
+  appUrl: http://localhost
+  appEnv: production
+  appDebug: "true"
+  requireHttps: "false"
+  phantomjsPdfGeneration: "false"
+  pdfGenerator: snappdf
+  trustedProxies: "*"
+  cacheDriver: redis
+  queueConnection: redis
+  sessionDriver: redis
+  redisPort: "6379"
+  filesystemDisk: debian_docker
+  dbPort: "3306"
+  dbDatabase: ninja
+  dbUsername: ninja
+  dbConnection: mysql
+  mailMailer: log
+  mailHost: smtp.mailtrap.io
+  mailPort: "2525"
+  mailUsername: "null"
+  mailPassword: "null"
+  mailEncryption: "null"
+  mailFromAddress: user@example.com
+  mailFromName: Self Hosted User
+  mysqlDatabase: ninja
+  mysqlUser: ninja
+  nordigenSecretId: ""
+  nordigenSecretKey: ""
+  isDocker: "true"
+  scoutDriver: "null"
+
+tolerations: []
+affinity: {}
+nodeSelector: {}

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -1,3 +1,17 @@
+namespace:
+  # Set to true to have the chart create and label the release namespace.
+  # The namespace is labelled enforce:baseline because the app container
+  # runs supervisord as root and MariaDB requires allowPrivilegeEscalation.
+  # warn/audit are set to restricted so remaining violations are still logged.
+  #
+  # If false, create and label the namespace manually before installing:
+  #   kubectl create namespace <name>
+  #   kubectl label namespace <name> \
+  #     pod-security.kubernetes.io/enforce=baseline \
+  #     pod-security.kubernetes.io/warn=restricted \
+  #     pod-security.kubernetes.io/audit=restricted
+  create: true
+
 nameOverride: ""
 fullnameOverride: ""
 
@@ -25,16 +39,37 @@ app:
   securityContext:
     allowPrivilegeEscalation: false
     readOnlyRootFilesystem: false
+    # runAsNonRoot cannot be set: the image starts supervisord as root.
+    # To harden this, the upstream image would need a non-root entrypoint.
+    capabilities:
+      # https://github.com/invoiceninja/dockerfiles/issues/769#issuecomment-3464415892
+      add:
+        - SETGID # needed for runuser
+        - SETUID # needed for runuser
+        - DAC_OVERRIDE # needed for mv
+        - FOWNER # needed for mv
+        - CHOWN # needed for mv
+      drop:
+        - ALL
+  initSecurityContext:
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 65534 # nobody — busybox has no named non-root user
     capabilities:
       drop:
         - ALL
 
 nginx:
   image:
-    repository: nginx
+    # nginx-unprivileged runs as uid 101 and listens on 8080, satisfying the
+    # restricted PodSecurity policy without needing the CHOWN capability.
+    repository: nginxinc/nginx-unprivileged
     tag: alpine
     pullPolicy: IfNotPresent
   replicaCount: 1
+  # containerPort must match the listen port in the nginx config.
+  # nginx-unprivileged cannot bind to ports < 1024; keep this at 8080.
+  containerPort: 8080
   service:
     type: ClusterIP
     port: 80
@@ -44,21 +79,22 @@ nginx:
       type: RuntimeDefault
   securityContext:
     allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 101 # nginx user in nginxinc/nginx-unprivileged
     capabilities:
-      add:
-        - CHOWN
       drop:
         - ALL
   initSecurityContext:
     allowPrivilegeEscalation: false
+    runAsNonRoot: true
     capabilities:
       drop:
         - ALL
 
 mysql:
   image:
-    repository: mysql
-    tag: "8"
+    repository: mariadb
+    tag: "lts"
     pullPolicy: IfNotPresent
   service:
     port: 3306
@@ -67,12 +103,12 @@ mysql:
     seccompProfile:
       type: RuntimeDefault
   securityContext:
-    # MySQL's initialization scripts require privilege escalation; this cannot
-    # be set to false without a custom entrypoint.
-    allowPrivilegeEscalation: true
+    allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 999 # mysql user in mariadb image
     capabilities:
       drop:
-        - NET_RAW
+        - ALL
   nodeSelector: {}
   affinity: {}
   tolerations: []
@@ -90,6 +126,8 @@ redis:
       type: RuntimeDefault
   securityContext:
     allowPrivilegeEscalation: false
+    runAsNonRoot: true
+    runAsUser: 999 # redis user in redis:alpine
     capabilities:
       drop:
         - ALL

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -6,8 +6,19 @@ app:
     repository: invoiceninja/invoiceninja-debian
     tag: latest
     pullPolicy: IfNotPresent
+  # Tag for the busybox init container that waits for MySQL/Redis.
+  busyboxTag: "1.36"
+  # NOTE: replicaCount > 1 requires ReadWriteMany storage for appPublic and
+  # appStorage. The default ReadWriteOnce PVCs can only bind to one node.
   replicaCount: 1
   resources: {}
+  # NOTE: you can set these if needed. You might need to tweak the values below
+  # resources:
+  #   requests:
+  #     cpu: 100m
+  #     memory: 256Mi
+  #   limits:
+  #     memory: 512Mi
   podSecurityContext:
     seccompProfile:
       type: RuntimeDefault
@@ -56,6 +67,8 @@ mysql:
     seccompProfile:
       type: RuntimeDefault
   securityContext:
+    # MySQL's initialization scripts require privilege escalation; this cannot
+    # be set to false without a custom entrypoint.
     allowPrivilegeEscalation: true
     capabilities:
       drop:
@@ -123,6 +136,8 @@ ingress:
   tls: []
 
 secret:
+  # REQUIRED: generate with `php artisan key:generate --show` or
+  # openssl rand -base64 32 | sed 's/^/base64:/'
   appKey: ""
   dbPassword: ninja
   dbRootPassword: ninjaAdm1nPassword
@@ -131,12 +146,14 @@ secret:
   inPassword: changeme!
 
 env:
+  # REQUIRED: set to the URL users will access the app on, e.g. https://invoices.example.com
   appUrl: http://localhost
   appEnv: production
-  appDebug: "true"
+  appDebug: "false"
   requireHttps: "false"
   phantomjsPdfGeneration: "false"
   pdfGenerator: snappdf
+  # trustedProxies: restrict to your ingress controller/gateway API's CIDR in production
   trustedProxies: "*"
   cacheDriver: redis
   queueConnection: redis
@@ -144,6 +161,8 @@ env:
   redisPort: "6379"
   filesystemDisk: debian_docker
   dbPort: "3306"
+  # dbDatabase and dbUsername are shared by both the app and the MySQL container.
+  # Change both env.dbDatabase/dbUsername and secret.dbPassword together.
   dbDatabase: ninja
   dbUsername: ninja
   dbConnection: mysql
@@ -155,8 +174,6 @@ env:
   mailEncryption: "null"
   mailFromAddress: user@example.com
   mailFromName: Self Hosted User
-  mysqlDatabase: ninja
-  mysqlUser: ninja
   nordigenSecretId: ""
   nordigenSecretKey: ""
   isDocker: "true"


### PR DESCRIPTION
This PR adds support to deploy IN to a Kubernetes cluster using Helm.

The chart is based on the current `docker-compose.yml`, and allows controlling several aspects of the installed release, including storage persistence, release version, and security context. See `values.yaml` for the defaults.

Tested on K8S 1.35.x using both a local dev (Talos on docker) and production clusters (Talos on baremetal).