### PR TITLE
Rescue Alpine-era uploads before public volume wipe

### DIFF
--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -19,6 +19,17 @@ if [ "$*" = 'supervisord -c /etc/supervisor/supervisord.conf' ]; then
     # Workaround for application updates
     if [ "$(ls -A /tmp/public)" ]; then
         echo "Updating public folder..."
+
+        # Migration: Alpine images stored uploads in public/storage as a real directory
+        # (not a symlink) because storage:link was never called and FILESYSTEM_DISK
+        # defaulted to 'public'. Move those files to storage/app/public before wiping
+        # the public volume so migrating users don't lose their uploaded documents.
+        if [ -d /var/www/html/public/storage ] && [ ! -L /var/www/html/public/storage ]; then
+            echo "Detected Alpine-era uploads in public/storage (real directory). Migrating to storage/app/public..."
+            cp -a /var/www/html/public/storage/. /var/www/html/storage/app/public/
+            echo "Alpine document migration complete."
+        fi
+
         rm -rf /var/www/html/public/.htaccess \
             /var/www/html/public/.well-known \
             /var/www/html/public/*


### PR DESCRIPTION
## Problem

When migrating from the Alpine image to the Debian image by swapping the image in docker-compose while reusing the same named volumes, all uploaded documents are silently destroyed on first start.

**Why:** Alpine never calls `storage:link` and never sets `FILESYSTEM_DISK`, so Laravel auto-creates `public/storage/` as a **real directory** on the public volume and writes all uploads there. Debian's `init.sh` then runs `rm -rf /var/www/html/public/*` on startup, wiping those uploads before the user has any chance to act.

## Fix

Before the `rm -rf`, detect if `public/storage` is a real directory (not a symlink). If it is, copy its contents to `storage/app/public/` (the correct Debian location) first.

On a normal Debian deployment `public/storage` is a symlink, so this block is skipped entirely — no impact to existing deployments.

Closes #874