### PR TITLE
feat: backup script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,13 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+.env
 
 # Helm
 charts/**/charts/
 
 # Compose filesystem
 /docker
+
+# Backups
+debian/backups/

--- a/README.md
+++ b/README.md
@@ -80,6 +80,44 @@ docker compose up -d
 
 It is recommended to perform a backup before updating.
 
+### Backup and Restore
+
+A backup script is included at `scripts/backup.sh`. It dumps the MySQL database and archives the storage volume into a single timestamped `.tar.gz` file.
+
+**Run from the `debian/` directory** (where `docker-compose.yml` lives):
+
+```bash
+./scripts/backup.sh
+```
+
+Backups are saved to `./backups/` by default. You can customise the behaviour with environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `BACKUP_DIR` | `./backups` | Directory to store backup archives |
+| `BACKUP_RETENTION_DAYS` | `30` | Auto-delete backups older than N days (0 = keep all) |
+
+**Schedule automatic backups** with cron (e.g. daily at 2 AM):
+
+```bash
+0 2 * * * cd /path/to/dockerfiles/debian && ./scripts/backup.sh >> /var/log/invoiceninja-backup.log 2>&1
+```
+
+**Restore** from a backup archive:
+
+```bash
+# Extract the archive
+tar xzf backups/invoiceninja-20250101-020000.tar.gz -C /tmp
+
+# Restore the database
+gunzip -c /tmp/invoiceninja-20250101-020000/db.sql.gz \
+  | docker compose exec -T mysql mysql -uninja -pninja ninja
+
+# Restore the storage volume
+docker compose exec -T app tar xzf - -C /var/www/html \
+  < /tmp/invoiceninja-20250101-020000/storage.tar.gz
+```
+
 ### Support
 
 If you discover a bug, please create an issue. For general queries, visit our [Forum](https://forum.invoiceninja.com/)
@@ -89,6 +127,6 @@ If you discover a bug, please create an issue. For general queries, visit our [F
 
 This is a new image which should provide much better support for all users, however there are some items left to complete
 
-- [ ] Backup script  
+- [x] Backup script  
 - [ ] Integrate soketi server  
 - [ ] Add elastic search for site wide search  

--- a/README.md
+++ b/README.md
@@ -82,40 +82,51 @@ It is recommended to perform a backup before updating.
 
 ### Backup and Restore
 
-A backup script is included at `scripts/backup.sh`. It dumps the MySQL database and archives the storage volume into a single timestamped `.tar.gz` file.
+Automatic backups run inside the `app` container via cron. The backup script dumps the MySQL database and archives the storage volume into timestamped `.tar.gz` files saved to `/backups` inside the container.
 
-**Run from the `debian/` directory** (where `docker-compose.yml` lives):
+**Schedule and retention:**
 
-```bash
-./scripts/backup.sh
+| Frequency | Retention |
+|---|---|
+| Daily | 7 days |
+| Weekly | 30 days |
+| Monthly | 120 days |
+
+Backups are stored in the `app_backups` volume by default. To access them from the host, swap the volume for a bind mount in `docker-compose.yml`:
+
+```yaml
+# - app_backups:/backups
+- ./backups:/backups
 ```
 
-Backups are saved to `./backups/` by default. You can customise the behaviour with environment variables:
-
-| Variable | Default | Description |
-|---|---|---|
-| `BACKUP_DIR` | `./backups` | Directory to store backup archives |
-| `BACKUP_RETENTION_DAYS` | `30` | Auto-delete backups older than N days (0 = keep all) |
-
-**Schedule automatic backups** with cron (e.g. daily at 2 AM):
+**Run a manual backup** (or override the built-in script via volume mount):
 
 ```bash
-0 2 * * * cd /path/to/dockerfiles/debian && ./scripts/backup.sh >> /var/log/invoiceninja-backup.log 2>&1
+docker compose exec app /usr/local/bin/backup.sh
+```
+
+To use a custom or modified backup script, uncomment the volume mount in `docker-compose.yml`:
+
+```yaml
+- ./scripts/backup.sh:/usr/local/bin/backup.sh:ro
 ```
 
 **Restore** from a backup archive:
 
 ```bash
+# Copy the backup from the container (or from the bind mount)
+docker compose cp app:/backups/2025-01-01-daily.tar.gz ./
+
 # Extract the archive
-tar xzf backups/invoiceninja-20250101-020000.tar.gz -C /tmp
+tar xzf 2025-01-01-daily.tar.gz -C /tmp
 
 # Restore the database
-gunzip -c /tmp/invoiceninja-20250101-020000/db.sql.gz \
+gunzip -c /tmp/2025-01-01-daily/db.sql.gz \
   | docker compose exec -T mysql mysql -uninja -pninja ninja
 
 # Restore the storage volume
 docker compose exec -T app tar xzf - -C /var/www/html \
-  < /tmp/invoiceninja-20250101-020000/storage.tar.gz
+  < /tmp/2025-01-01-daily/storage.tar.gz
 ```
 
 ### Support

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -24,6 +24,7 @@ ARG php_extra="opcache"
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
+    cron \
     libfcgi-bin \
     mariadb-client \
     gpg \
@@ -79,6 +80,12 @@ COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 # Setup InvoiceNinja
 COPY --from=prepare-app --chown=www-data:www-data /var/www/html /var/www/html
 COPY --from=prepare-app --chown=www-data:www-data /tmp/public /tmp/public
+
+# Add backup script with cron symlinks for daily/weekly/monthly
+COPY --chmod=0755 scripts/backup.sh /usr/local/bin/backup.sh
+RUN ln -s /usr/local/bin/backup.sh /etc/cron.daily/daily \
+ && ln -s /usr/local/bin/backup.sh /etc/cron.weekly/weekly \
+ && ln -s /usr/local/bin/backup.sh /etc/cron.monthly/monthly
 
 # Add initialization script
 COPY --chmod=0755 scripts/init.sh /usr/local/bin/init.sh

--- a/debian/docker-compose.yml
+++ b/debian/docker-compose.yml
@@ -10,8 +10,12 @@ services:
       # - ./php/php.ini:/usr/local/etc/php/conf.d/invoiceninja.ini:ro
       # - ./php/php-fpm.conf:/usr/local/etc/php-fpm.d/invoiceninja.conf:ro
       # - ./supervisor/supervisord.conf:/etc/supervisor/conf.d/supervisord.conf:ro
+      # - ./scripts/backup.sh:/usr/local/bin/backup.sh:ro
       - app_public:/var/www/html/public
       - app_storage:/var/www/html/storage
+      # Backups – use a bind mount to access from the host:
+      # - ./backups:/backups
+      - app_backups:/backups
     depends_on:
       mysql:
         condition: service_healthy
@@ -69,4 +73,6 @@ volumes:
   mysql_data:
     driver: local
   redis_data:
+    driver: local
+  app_backups:
     driver: local

--- a/debian/scripts/backup.sh
+++ b/debian/scripts/backup.sh
@@ -2,98 +2,83 @@
 set -eu
 
 # Invoice Ninja Docker – Backup Script
-# Backs up the MySQL database and the storage volume.
-# Run from the debian/ directory (where docker-compose.yml lives).
 #
-# Usage:
-#   ./scripts/backup.sh              # backup with defaults
-#   BACKUP_DIR=/mnt/nas ./scripts/backup.sh
+# When symlinked into /etc/cron.daily, /etc/cron.weekly, or /etc/cron.monthly
+# the script uses its invocation name to set the backup frequency and retention.
+# It can also be run manually: /usr/local/bin/backup.sh
 #
-# Environment variables (all optional):
-#   BACKUP_DIR             – where to store backups     (default: ./backups)
-#   BACKUP_RETENTION_DAYS  – delete backups older than  (default: 30, 0 = keep all)
-#   COMPOSE_PROJECT        – docker compose project     (default: auto-detected)
+# Retention defaults:
+#   daily   –  7 days
+#   weekly  – 30 days
+#   monthly – 120 days
+#   manual  – 30 days
 
-BACKUP_DIR="${BACKUP_DIR:-./backups}"
-BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
-TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
-BACKUP_NAME="invoiceninja-${TIMESTAMP}"
+FREQUENCY="$(basename "$0")"
+
+case "${FREQUENCY}" in
+    daily)   RETENTION_DAYS=7   ;;
+    weekly)  RETENTION_DAYS=30  ;;
+    monthly) RETENTION_DAYS=120 ;;
+    *)       FREQUENCY="manual"; RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}" ;;
+esac
+
+BACKUP_DIR="${BACKUP_DIR:-/backups}"
+STORAGE_PATH="${STORAGE_PATH:-/var/www/html/storage}"
+TIMESTAMP="$(date +%Y-%m-%d)"
+BACKUP_NAME="${TIMESTAMP}-${FREQUENCY}"
 BACKUP_PATH="${BACKUP_DIR}/${BACKUP_NAME}"
 
-COMPOSE_CMD="docker compose"
-if [ -n "${COMPOSE_PROJECT:-}" ]; then
-    COMPOSE_CMD="docker compose -p ${COMPOSE_PROJECT}"
-fi
+DB_HOST="${DB_HOST:-mysql}"
+DB_PORT="${DB_PORT:-3306}"
+DB_DATABASE="${DB_DATABASE:?DB_DATABASE is not set}"
+DB_USERNAME="${DB_USERNAME:?DB_USERNAME is not set}"
+DB_PASSWORD="${DB_PASSWORD:?DB_PASSWORD is not set}"
 
 die() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
 
 # ---------------------------------------------------------------------------
-# Preflight checks
+# Preflight
 # ---------------------------------------------------------------------------
-command -v docker >/dev/null 2>&1 || die "docker is not installed or not in PATH"
+command -v mysqldump >/dev/null 2>&1 || die "mysqldump is not installed"
+[ -d "${STORAGE_PATH}" ] || die "${STORAGE_PATH} does not exist"
+mkdir -p "${BACKUP_DIR}"
 
-# Verify the containers we need are running
-for svc in mysql app; do
-    ${COMPOSE_CMD} ps --status running --format '{{.Service}}' 2>/dev/null \
-        | grep -qx "${svc}" \
-        || die "'${svc}' service is not running. Start the stack first: docker compose up -d"
-done
-
-# Read DB credentials from the .env file next to docker-compose.yml
-ENV_FILE="$(dirname "$(dirname "$0")")/.env"
-if [ -f "${ENV_FILE}" ]; then
-    DB_DATABASE="$(grep -E '^DB_DATABASE=' "${ENV_FILE}" | cut -d= -f2-)"
-    DB_USERNAME="$(grep -E '^DB_USERNAME=' "${ENV_FILE}" | cut -d= -f2-)"
-    DB_PASSWORD="$(grep -E '^DB_PASSWORD=' "${ENV_FILE}" | cut -d= -f2-)"
-fi
-
-DB_DATABASE="${DB_DATABASE:?DB_DATABASE is not set – check .env}"
-DB_USERNAME="${DB_USERNAME:?DB_USERNAME is not set – check .env}"
-DB_PASSWORD="${DB_PASSWORD:?DB_PASSWORD is not set – check .env}"
-
-# ---------------------------------------------------------------------------
-# Create backup directory
-# ---------------------------------------------------------------------------
-mkdir -p "${BACKUP_PATH}"
-
-echo "Starting backup → ${BACKUP_PATH}"
+echo "[backup] Starting ${FREQUENCY} backup → ${BACKUP_PATH}"
 
 # ---------------------------------------------------------------------------
 # 1. Database dump
 # ---------------------------------------------------------------------------
-echo "  Dumping database '${DB_DATABASE}'..."
-${COMPOSE_CMD} exec -T mysql \
-    mysqldump -u"${DB_USERNAME}" -p"${DB_PASSWORD}" \
-    --single-transaction --routines --triggers \
+mkdir -p "${BACKUP_PATH}"
+
+echo "[backup] Dumping database '${DB_DATABASE}'..."
+mysqldump -h"${DB_HOST}" -P"${DB_PORT}" \
+    -u"${DB_USERNAME}" -p"${DB_PASSWORD}" \
+    --single-transaction --no-tablespaces --routines --triggers \
     "${DB_DATABASE}" \
     | gzip > "${BACKUP_PATH}/db.sql.gz"
-echo "  Database dump complete."
 
 # ---------------------------------------------------------------------------
 # 2. Storage volume
 # ---------------------------------------------------------------------------
-echo "  Archiving storage volume..."
-${COMPOSE_CMD} exec -T app \
-    tar czf - -C /var/www/html storage \
-    > "${BACKUP_PATH}/storage.tar.gz"
-echo "  Storage archive complete."
+echo "[backup] Archiving storage volume..."
+tar czf "${BACKUP_PATH}/storage.tar.gz" -C "$(dirname "${STORAGE_PATH}")" "$(basename "${STORAGE_PATH}")"
 
 # ---------------------------------------------------------------------------
-# 3. Bundle into a single archive and clean up the temp directory
+# 3. Bundle into a single archive
 # ---------------------------------------------------------------------------
 tar czf "${BACKUP_DIR}/${BACKUP_NAME}.tar.gz" -C "${BACKUP_DIR}" "${BACKUP_NAME}"
 rm -rf "${BACKUP_PATH}"
-echo "Backup saved to ${BACKUP_DIR}/${BACKUP_NAME}.tar.gz"
+echo "[backup] Saved ${BACKUP_DIR}/${BACKUP_NAME}.tar.gz"
 
 # ---------------------------------------------------------------------------
-# 4. Retention – remove old backups
+# 4. Retention – remove old backups of the same frequency
 # ---------------------------------------------------------------------------
-if [ "${BACKUP_RETENTION_DAYS}" -gt 0 ] 2>/dev/null; then
-    DELETED=$(find "${BACKUP_DIR}" -maxdepth 1 -name 'invoiceninja-*.tar.gz' \
-        -type f -mtime +"${BACKUP_RETENTION_DAYS}" -print -delete | wc -l)
+if [ "${RETENTION_DAYS}" -gt 0 ] 2>/dev/null; then
+    DELETED=$(find "${BACKUP_DIR}" -maxdepth 1 -name "*-${FREQUENCY}.tar.gz" \
+        -type f -mtime +"${RETENTION_DAYS}" -print -delete | wc -l)
     if [ "${DELETED}" -gt 0 ]; then
-        echo "Cleaned up ${DELETED} backup(s) older than ${BACKUP_RETENTION_DAYS} days."
+        echo "[backup] Cleaned up ${DELETED} ${FREQUENCY} backup(s) older than ${RETENTION_DAYS} days."
     fi
 fi
 
-echo "Done."
+echo "[backup] Done."

--- a/debian/scripts/backup.sh
+++ b/debian/scripts/backup.sh
@@ -1,0 +1,99 @@
+#!/bin/sh
+set -eu
+
+# Invoice Ninja Docker – Backup Script
+# Backs up the MySQL database and the storage volume.
+# Run from the debian/ directory (where docker-compose.yml lives).
+#
+# Usage:
+#   ./scripts/backup.sh              # backup with defaults
+#   BACKUP_DIR=/mnt/nas ./scripts/backup.sh
+#
+# Environment variables (all optional):
+#   BACKUP_DIR             – where to store backups     (default: ./backups)
+#   BACKUP_RETENTION_DAYS  – delete backups older than  (default: 30, 0 = keep all)
+#   COMPOSE_PROJECT        – docker compose project     (default: auto-detected)
+
+BACKUP_DIR="${BACKUP_DIR:-./backups}"
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-30}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP_NAME="invoiceninja-${TIMESTAMP}"
+BACKUP_PATH="${BACKUP_DIR}/${BACKUP_NAME}"
+
+COMPOSE_CMD="docker compose"
+if [ -n "${COMPOSE_PROJECT:-}" ]; then
+    COMPOSE_CMD="docker compose -p ${COMPOSE_PROJECT}"
+fi
+
+die() { printf 'ERROR: %s\n' "$1" >&2; exit 1; }
+
+# ---------------------------------------------------------------------------
+# Preflight checks
+# ---------------------------------------------------------------------------
+command -v docker >/dev/null 2>&1 || die "docker is not installed or not in PATH"
+
+# Verify the containers we need are running
+for svc in mysql app; do
+    ${COMPOSE_CMD} ps --status running --format '{{.Service}}' 2>/dev/null \
+        | grep -qx "${svc}" \
+        || die "'${svc}' service is not running. Start the stack first: docker compose up -d"
+done
+
+# Read DB credentials from the .env file next to docker-compose.yml
+ENV_FILE="$(dirname "$(dirname "$0")")/.env"
+if [ -f "${ENV_FILE}" ]; then
+    DB_DATABASE="$(grep -E '^DB_DATABASE=' "${ENV_FILE}" | cut -d= -f2-)"
+    DB_USERNAME="$(grep -E '^DB_USERNAME=' "${ENV_FILE}" | cut -d= -f2-)"
+    DB_PASSWORD="$(grep -E '^DB_PASSWORD=' "${ENV_FILE}" | cut -d= -f2-)"
+fi
+
+DB_DATABASE="${DB_DATABASE:?DB_DATABASE is not set – check .env}"
+DB_USERNAME="${DB_USERNAME:?DB_USERNAME is not set – check .env}"
+DB_PASSWORD="${DB_PASSWORD:?DB_PASSWORD is not set – check .env}"
+
+# ---------------------------------------------------------------------------
+# Create backup directory
+# ---------------------------------------------------------------------------
+mkdir -p "${BACKUP_PATH}"
+
+echo "Starting backup → ${BACKUP_PATH}"
+
+# ---------------------------------------------------------------------------
+# 1. Database dump
+# ---------------------------------------------------------------------------
+echo "  Dumping database '${DB_DATABASE}'..."
+${COMPOSE_CMD} exec -T mysql \
+    mysqldump -u"${DB_USERNAME}" -p"${DB_PASSWORD}" \
+    --single-transaction --routines --triggers \
+    "${DB_DATABASE}" \
+    | gzip > "${BACKUP_PATH}/db.sql.gz"
+echo "  Database dump complete."
+
+# ---------------------------------------------------------------------------
+# 2. Storage volume
+# ---------------------------------------------------------------------------
+echo "  Archiving storage volume..."
+${COMPOSE_CMD} exec -T app \
+    tar czf - -C /var/www/html storage \
+    > "${BACKUP_PATH}/storage.tar.gz"
+echo "  Storage archive complete."
+
+# ---------------------------------------------------------------------------
+# 3. Bundle into a single archive and clean up the temp directory
+# ---------------------------------------------------------------------------
+tar czf "${BACKUP_DIR}/${BACKUP_NAME}.tar.gz" -C "${BACKUP_DIR}" "${BACKUP_NAME}"
+rm -rf "${BACKUP_PATH}"
+echo "Backup saved to ${BACKUP_DIR}/${BACKUP_NAME}.tar.gz"
+
+# ---------------------------------------------------------------------------
+# 4. Retention – remove old backups
+# ---------------------------------------------------------------------------
+if [ "${BACKUP_RETENTION_DAYS}" -gt 0 ] 2>/dev/null; then
+    DELETED=$(find "${BACKUP_DIR}" -maxdepth 1 -name 'invoiceninja-*.tar.gz' \
+        -type f -mtime +"${BACKUP_RETENTION_DAYS}" -print -delete | wc -l)
+    if [ "${DELETED}" -gt 0 ]; then
+        echo "Cleaned up ${DELETED} backup(s) older than ${BACKUP_RETENTION_DAYS} days."
+    fi
+fi
+
+echo "Done."

--- a/debian/scripts/init.sh
+++ b/debian/scripts/init.sh
@@ -10,6 +10,7 @@ fi
 if [ "$*" = 'supervisord -c /etc/supervisor/supervisord.conf' ]; then
 
     # Check for required folders and create if needed
+    [ -d /backups ] || mkdir -p /backups
     [ -d /var/www/html/public ] || mkdir -p /var/www/html/public
     [ -d /var/www/html/storage/app/public ] || mkdir -p /var/www/html/storage/app/public
     [ -d /var/www/html/storage/framework/sessions ] || mkdir -p /var/www/html/storage/framework/sessions

--- a/debian/scripts/test_backup.sh
+++ b/debian/scripts/test_backup.sh
@@ -1,0 +1,172 @@
+#!/bin/sh
+# Temporary test harness for backup.sh – validates logic with a mock docker.
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TEST_DIR="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+cleanup() { rm -rf "${TEST_DIR}"; }
+trap cleanup EXIT
+
+pass() { PASS=$((PASS + 1)); printf '  ✓ %s\n' "$1"; }
+fail() { FAIL=$((FAIL + 1)); printf '  ✗ %s\n' "$1"; }
+
+# ---------------------------------------------------------------------------
+# Setup: create a fake debian/ tree with .env and a mock `docker` binary
+# ---------------------------------------------------------------------------
+FAKE_DEBIAN="${TEST_DIR}/debian"
+mkdir -p "${FAKE_DEBIAN}/scripts"
+cp "${SCRIPT_DIR}/backup.sh" "${FAKE_DEBIAN}/scripts/backup.sh"
+
+cat > "${FAKE_DEBIAN}/.env" <<'DOTENV'
+DB_DATABASE=testdb
+DB_USERNAME=testuser
+DB_PASSWORD=testpass
+DOTENV
+
+# Mock docker binary that simulates compose commands
+MOCK_BIN="${TEST_DIR}/bin"
+mkdir -p "${MOCK_BIN}"
+cat > "${MOCK_BIN}/docker" <<'MOCK'
+#!/bin/sh
+# Intercept `docker compose` subcommands
+case "$*" in
+    *"ps --status running"*)
+        printf 'mysql\napp\n'
+        ;;
+    *"exec -T mysql mysqldump"*)
+        printf 'CREATE TABLE dummy;\n'
+        ;;
+    *"exec -T app tar"*)
+        # produce a tiny valid gzip stream (empty tar)
+        tar czf - --files-from /dev/null
+        ;;
+    *)
+        printf 'mock docker called: %s\n' "$*" >&2
+        ;;
+esac
+MOCK
+chmod +x "${MOCK_BIN}/docker"
+
+# ---------------------------------------------------------------------------
+# Test 1: Successful backup creates archive
+# ---------------------------------------------------------------------------
+echo "Test 1: basic backup"
+BACKUP_OUT="${TEST_DIR}/backups_t1"
+(
+    cd "${FAKE_DEBIAN}"
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT}" BACKUP_RETENTION_DAYS=0 \
+        sh scripts/backup.sh > /dev/null 2>&1
+)
+ARCHIVE=$(find "${BACKUP_OUT}" -maxdepth 1 -name 'invoiceninja-*.tar.gz' | head -1)
+if [ -n "${ARCHIVE}" ] && [ -f "${ARCHIVE}" ]; then
+    pass "archive created: $(basename "${ARCHIVE}")"
+else
+    fail "no archive found in ${BACKUP_OUT}"
+fi
+
+# Verify the archive contains db.sql.gz and storage.tar.gz
+if tar tzf "${ARCHIVE}" 2>/dev/null | grep -q 'db.sql.gz'; then
+    pass "archive contains db.sql.gz"
+else
+    fail "archive missing db.sql.gz"
+fi
+if tar tzf "${ARCHIVE}" 2>/dev/null | grep -q 'storage.tar.gz'; then
+    pass "archive contains storage.tar.gz"
+else
+    fail "archive missing storage.tar.gz"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: Retention deletes old backups
+# ---------------------------------------------------------------------------
+echo "Test 2: retention cleanup"
+BACKUP_OUT2="${TEST_DIR}/backups_t2"
+mkdir -p "${BACKUP_OUT2}"
+# Create a fake old backup (touch with old date)
+OLD_FILE="${BACKUP_OUT2}/invoiceninja-19990101-000000.tar.gz"
+touch "${OLD_FILE}"
+# backdate it on macOS (uses -t) or Linux (uses -d)
+if touch -t 199901010000 "${OLD_FILE}" 2>/dev/null; then
+    :
+else
+    touch -d "60 days ago" "${OLD_FILE}" 2>/dev/null || true
+fi
+
+(
+    cd "${FAKE_DEBIAN}"
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT2}" BACKUP_RETENTION_DAYS=7 \
+        sh scripts/backup.sh > /dev/null 2>&1
+)
+if [ ! -f "${OLD_FILE}" ]; then
+    pass "old backup was cleaned up"
+else
+    fail "old backup was NOT cleaned up"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 3: Fails when a service is not running
+# ---------------------------------------------------------------------------
+echo "Test 3: fails when service is down"
+cat > "${MOCK_BIN}/docker" <<'MOCK2'
+#!/bin/sh
+case "$*" in
+    *"ps --status running"*)
+        printf 'app\n'   # mysql is missing
+        ;;
+    *) ;;
+esac
+MOCK2
+chmod +x "${MOCK_BIN}/docker"
+
+BACKUP_OUT3="${TEST_DIR}/backups_t3"
+if (
+    cd "${FAKE_DEBIAN}"
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT3}" \
+        sh scripts/backup.sh > /dev/null 2>&1
+); then
+    fail "should have exited non-zero when mysql is down"
+else
+    pass "correctly failed when mysql service is down"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 4: Fails with missing .env credentials
+# ---------------------------------------------------------------------------
+echo "Test 4: fails with missing credentials"
+# Restore working mock
+cat > "${MOCK_BIN}/docker" <<'MOCK3'
+#!/bin/sh
+case "$*" in
+    *"ps --status running"*)
+        printf 'mysql\napp\n'
+        ;;
+    *) ;;
+esac
+MOCK3
+chmod +x "${MOCK_BIN}/docker"
+
+EMPTY_DEBIAN="${TEST_DIR}/empty_debian"
+mkdir -p "${EMPTY_DEBIAN}/scripts"
+cp "${SCRIPT_DIR}/backup.sh" "${EMPTY_DEBIAN}/scripts/backup.sh"
+touch "${EMPTY_DEBIAN}/.env"   # empty .env
+
+BACKUP_OUT4="${TEST_DIR}/backups_t4"
+if (
+    cd "${EMPTY_DEBIAN}"
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT4}" \
+        sh scripts/backup.sh > /dev/null 2>&1
+); then
+    fail "should have exited non-zero with empty .env"
+else
+    pass "correctly failed with missing DB credentials"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+[ "${FAIL}" -eq 0 ] || exit 1

--- a/debian/scripts/test_backup.sh
+++ b/debian/scripts/test_backup.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Temporary test harness for backup.sh – validates logic with a mock docker.
+# Temporary test harness for backup.sh – validates in-container logic with mocks.
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -14,60 +14,48 @@ pass() { PASS=$((PASS + 1)); printf '  ✓ %s\n' "$1"; }
 fail() { FAIL=$((FAIL + 1)); printf '  ✗ %s\n' "$1"; }
 
 # ---------------------------------------------------------------------------
-# Setup: create a fake debian/ tree with .env and a mock `docker` binary
+# Setup: fake storage dir, mock mysqldump, and env vars
 # ---------------------------------------------------------------------------
-FAKE_DEBIAN="${TEST_DIR}/debian"
-mkdir -p "${FAKE_DEBIAN}/scripts"
-cp "${SCRIPT_DIR}/backup.sh" "${FAKE_DEBIAN}/scripts/backup.sh"
+FAKE_STORAGE="${TEST_DIR}/storage"
+mkdir -p "${FAKE_STORAGE}/app/public"
+echo "test file" > "${FAKE_STORAGE}/app/public/testfile.txt"
 
-cat > "${FAKE_DEBIAN}/.env" <<'DOTENV'
-DB_DATABASE=testdb
-DB_USERNAME=testuser
-DB_PASSWORD=testpass
-DOTENV
-
-# Mock docker binary that simulates compose commands
 MOCK_BIN="${TEST_DIR}/bin"
 mkdir -p "${MOCK_BIN}"
-cat > "${MOCK_BIN}/docker" <<'MOCK'
+cat > "${MOCK_BIN}/mysqldump" <<'MOCK'
 #!/bin/sh
-# Intercept `docker compose` subcommands
-case "$*" in
-    *"ps --status running"*)
-        printf 'mysql\napp\n'
-        ;;
-    *"exec -T mysql mysqldump"*)
-        printf 'CREATE TABLE dummy;\n'
-        ;;
-    *"exec -T app tar"*)
-        # produce a tiny valid gzip stream (empty tar)
-        tar czf - --files-from /dev/null
-        ;;
-    *)
-        printf 'mock docker called: %s\n' "$*" >&2
-        ;;
-esac
+printf 'CREATE TABLE dummy;\n'
 MOCK
-chmod +x "${MOCK_BIN}/docker"
+chmod +x "${MOCK_BIN}/mysqldump"
+
+export DB_HOST=localhost
+export DB_PORT=3306
+export DB_DATABASE=testdb
+export DB_USERNAME=testuser
+export DB_PASSWORD=testpass
+export STORAGE_PATH="${FAKE_STORAGE}"
+
+TODAY="$(date +%Y-%m-%d)"
 
 # ---------------------------------------------------------------------------
-# Test 1: Successful backup creates archive
+# Test 1: Daily backup via basename symlink
 # ---------------------------------------------------------------------------
-echo "Test 1: basic backup"
+echo "Test 1: daily backup (basename detection)"
 BACKUP_OUT="${TEST_DIR}/backups_t1"
+ln -sf "${SCRIPT_DIR}/backup.sh" "${TEST_DIR}/daily"
+
 (
-    cd "${FAKE_DEBIAN}"
-    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT}" BACKUP_RETENTION_DAYS=0 \
-        sh scripts/backup.sh > /dev/null 2>&1
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT}" \
+        sh "${TEST_DIR}/daily" > /dev/null 2>&1
 )
-ARCHIVE=$(find "${BACKUP_OUT}" -maxdepth 1 -name 'invoiceninja-*.tar.gz' | head -1)
-if [ -n "${ARCHIVE}" ] && [ -f "${ARCHIVE}" ]; then
-    pass "archive created: $(basename "${ARCHIVE}")"
+
+ARCHIVE="${BACKUP_OUT}/${TODAY}-daily.tar.gz"
+if [ -f "${ARCHIVE}" ]; then
+    pass "daily archive created: $(basename "${ARCHIVE}")"
 else
-    fail "no archive found in ${BACKUP_OUT}"
+    fail "daily archive not found at ${ARCHIVE}"
 fi
 
-# Verify the archive contains db.sql.gz and storage.tar.gz
 if tar tzf "${ARCHIVE}" 2>/dev/null | grep -q 'db.sql.gz'; then
     pass "archive contains db.sql.gz"
 else
@@ -80,86 +68,98 @@ else
 fi
 
 # ---------------------------------------------------------------------------
-# Test 2: Retention deletes old backups
+# Test 2: Weekly backup via basename
 # ---------------------------------------------------------------------------
-echo "Test 2: retention cleanup"
+echo "Test 2: weekly backup (basename detection)"
 BACKUP_OUT2="${TEST_DIR}/backups_t2"
-mkdir -p "${BACKUP_OUT2}"
-# Create a fake old backup (touch with old date)
-OLD_FILE="${BACKUP_OUT2}/invoiceninja-19990101-000000.tar.gz"
-touch "${OLD_FILE}"
-# backdate it on macOS (uses -t) or Linux (uses -d)
-if touch -t 199901010000 "${OLD_FILE}" 2>/dev/null; then
-    :
-else
-    touch -d "60 days ago" "${OLD_FILE}" 2>/dev/null || true
-fi
+ln -sf "${SCRIPT_DIR}/backup.sh" "${TEST_DIR}/weekly"
 
 (
-    cd "${FAKE_DEBIAN}"
-    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT2}" BACKUP_RETENTION_DAYS=7 \
-        sh scripts/backup.sh > /dev/null 2>&1
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT2}" \
+        sh "${TEST_DIR}/weekly" > /dev/null 2>&1
 )
-if [ ! -f "${OLD_FILE}" ]; then
-    pass "old backup was cleaned up"
+
+ARCHIVE2="${BACKUP_OUT2}/${TODAY}-weekly.tar.gz"
+if [ -f "${ARCHIVE2}" ]; then
+    pass "weekly archive created: $(basename "${ARCHIVE2}")"
 else
-    fail "old backup was NOT cleaned up"
+    fail "weekly archive not found at ${ARCHIVE2}"
 fi
 
 # ---------------------------------------------------------------------------
-# Test 3: Fails when a service is not running
+# Test 3: Monthly backup via basename
 # ---------------------------------------------------------------------------
-echo "Test 3: fails when service is down"
-cat > "${MOCK_BIN}/docker" <<'MOCK2'
-#!/bin/sh
-case "$*" in
-    *"ps --status running"*)
-        printf 'app\n'   # mysql is missing
-        ;;
-    *) ;;
-esac
-MOCK2
-chmod +x "${MOCK_BIN}/docker"
-
+echo "Test 3: monthly backup (basename detection)"
 BACKUP_OUT3="${TEST_DIR}/backups_t3"
-if (
-    cd "${FAKE_DEBIAN}"
+ln -sf "${SCRIPT_DIR}/backup.sh" "${TEST_DIR}/monthly"
+
+(
     PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT3}" \
-        sh scripts/backup.sh > /dev/null 2>&1
-); then
-    fail "should have exited non-zero when mysql is down"
+        sh "${TEST_DIR}/monthly" > /dev/null 2>&1
+)
+
+ARCHIVE3="${BACKUP_OUT3}/${TODAY}-monthly.tar.gz"
+if [ -f "${ARCHIVE3}" ]; then
+    pass "monthly archive created: $(basename "${ARCHIVE3}")"
 else
-    pass "correctly failed when mysql service is down"
+    fail "monthly archive not found at ${ARCHIVE3}"
 fi
 
 # ---------------------------------------------------------------------------
-# Test 4: Fails with missing .env credentials
+# Test 4: Manual invocation (basename = backup.sh -> frequency = manual)
 # ---------------------------------------------------------------------------
-echo "Test 4: fails with missing credentials"
-# Restore working mock
-cat > "${MOCK_BIN}/docker" <<'MOCK3'
-#!/bin/sh
-case "$*" in
-    *"ps --status running"*)
-        printf 'mysql\napp\n'
-        ;;
-    *) ;;
-esac
-MOCK3
-chmod +x "${MOCK_BIN}/docker"
-
-EMPTY_DEBIAN="${TEST_DIR}/empty_debian"
-mkdir -p "${EMPTY_DEBIAN}/scripts"
-cp "${SCRIPT_DIR}/backup.sh" "${EMPTY_DEBIAN}/scripts/backup.sh"
-touch "${EMPTY_DEBIAN}/.env"   # empty .env
-
+echo "Test 4: manual invocation (basename fallback)"
 BACKUP_OUT4="${TEST_DIR}/backups_t4"
-if (
-    cd "${EMPTY_DEBIAN}"
+
+(
     PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT4}" \
-        sh scripts/backup.sh > /dev/null 2>&1
+        sh "${SCRIPT_DIR}/backup.sh" > /dev/null 2>&1
+)
+
+ARCHIVE4="${BACKUP_OUT4}/${TODAY}-manual.tar.gz"
+if [ -f "${ARCHIVE4}" ]; then
+    pass "manual archive created: $(basename "${ARCHIVE4}")"
+else
+    fail "manual archive not found at ${ARCHIVE4}"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 5: Retention deletes old backups of matching frequency
+# ---------------------------------------------------------------------------
+echo "Test 5: retention cleanup"
+BACKUP_OUT5="${TEST_DIR}/backups_t5"
+mkdir -p "${BACKUP_OUT5}"
+
+OLD_FILE="${BACKUP_OUT5}/1999-01-01-daily.tar.gz"
+touch "${OLD_FILE}"
+if touch -t 199901010000 "${OLD_FILE}" 2>/dev/null; then :
+else touch -d "60 days ago" "${OLD_FILE}" 2>/dev/null || true; fi
+
+ln -sf "${SCRIPT_DIR}/backup.sh" "${TEST_DIR}/daily"
+
+(
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT5}" \
+        sh "${TEST_DIR}/daily" > /dev/null 2>&1
+)
+
+if [ ! -f "${OLD_FILE}" ]; then
+    pass "old daily backup was cleaned up"
+else
+    fail "old daily backup was NOT cleaned up"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 6: Fails with missing DB credentials
+# ---------------------------------------------------------------------------
+echo "Test 6: fails with missing credentials"
+BACKUP_OUT6="${TEST_DIR}/backups_t6"
+
+if (
+    unset DB_DATABASE DB_USERNAME DB_PASSWORD
+    PATH="${MOCK_BIN}:${PATH}" BACKUP_DIR="${BACKUP_OUT6}" \
+        sh "${SCRIPT_DIR}/backup.sh" > /dev/null 2>&1
 ); then
-    fail "should have exited non-zero with empty .env"
+    fail "should have exited non-zero with missing credentials"
 else
     pass "correctly failed with missing DB credentials"
 fi

--- a/debian/supervisor/supervisord.conf
+++ b/debian/supervisor/supervisord.conf
@@ -37,3 +37,12 @@ user=www-data
 stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 redirect_stderr=true
+
+[program:cron]
+command=/usr/sbin/cron -f
+autostart=true
+autorestart=true
+priority=10
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true


### PR DESCRIPTION
## Summary

- Automatic daily/weekly/monthly backups via cron inside the app container
- Backs up MySQL (mysqldump) + storage volume into timestamped `.tar.gz` archives (format YYYY-MM-DD-<frequency>.tar.gz)
- Tiered retention: daily 7d, weekly 30d, monthly 120d (took inspiration from your old master branch here)
- Uses basename/symlink pattern (also similar to your old master)

## Changes

- `debian/scripts/backup.sh` – backup script with frequency detection via `basename`
- `debian/Dockerfile` – add `cron`, copy script, symlink to cron.daily/weekly/monthly
- `debian/supervisor/supervisord.conf` – add `[program:cron]`
- `debian/docker-compose.yml` – add `app_backups` volume
- `debian/scripts/init.sh` – ensure `/backups` dir on startup
- `README.md` – backup/restore docs, checked off todo
- `debian/scripts/test_backup.sh` – shell unit test **(can be removed if unwanted ofc)**