### PR TITLE
fix: disable unused Supervisor control socket

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -82,7 +82,10 @@ COPY php/php-fpm.conf /usr/local/etc/php-fpm.d/invoiceninja.conf
 RUN echo "skip-ssl = true" >> /etc/mysql/mariadb.conf.d/50-client.cnf
 
 # Setup supervisor
-COPY supervisor/supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+# New top-level conf
+COPY supervisor/supervisord.conf /etc/supervisor/supervisord.conf
+# Invoice Ninja Programs
+COPY supervisor/programs.conf /etc/supervisor/conf.d/programs.conf
 
 # Setup InvoiceNinja
 COPY --from=prepare-app --chown=www-data:www-data /var/www/html /var/www/html

--- a/debian/supervisor/programs.conf
+++ b/debian/supervisor/programs.conf
@@ -1,0 +1,32 @@
+[program:php-fpm]
+command=/usr/local/sbin/php-fpm -F
+autostart=true
+autorestart=true
+priority=5
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+
+[program:queue-worker]
+process_name=%(program_name)s_%(process_num)02d
+command=php /var/www/html/artisan queue:work --sleep=3 --tries=3 --max-time=3600 --verbose
+autostart=true
+autorestart=true
+stopasgroup=true
+killasgroup=true
+user=www-data
+numprocs=2
+environment=HOME="/var/www"
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
+stopwaitsecs=3600
+
+[program:scheduler]
+command=php /var/www/html/artisan schedule:work --verbose
+autostart=true
+autorestart=true
+user=www-data
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true

--- a/debian/supervisor/supervisord.conf
+++ b/debian/supervisor/supervisord.conf
@@ -1,3 +1,8 @@
+; supervisor config file
+; Deliberately owned by the Invoice Ninja image: Debian's default config enables
+; an unused Supervisor XML-RPC UNIX socket, which emits a CRIT startup message.
+; Review this file when upgrading the Supervisor package.
+
 [supervisord]
 nodaemon=true
 user=root
@@ -5,35 +10,11 @@ logfile=/dev/null
 logfile_maxbytes=0
 pidfile=/var/run/supervisord.pid
 
-[program:php-fpm]
-command=/usr/local/sbin/php-fpm -F
-autostart=true
-autorestart=true
-priority=5
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
+; The [include] section can just contain the "files" setting.  This
+; setting can list multiple files (separated by whitespace or
+; newlines).  It can also contain wildcards.  The filenames are
+; interpreted as relative to this file.  Included files *cannot*
+; include files themselves.
 
-[program:queue-worker]
-process_name=%(program_name)s_%(process_num)02d
-command=php /var/www/html/artisan queue:work --sleep=3 --tries=3 --max-time=3600 --verbose
-autostart=true
-autorestart=true
-stopasgroup=true
-killasgroup=true
-user=www-data
-numprocs=2
-environment=HOME="/var/www"
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
-stopwaitsecs=3600
-
-[program:scheduler]
-command=php /var/www/html/artisan schedule:work --verbose
-autostart=true
-autorestart=true
-user=www-data
-stdout_logfile=/dev/fd/1
-stdout_logfile_maxbytes=0
-redirect_stderr=true
+[include]
+files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
Closes #882

## Summary

- Replace Debian's inherited top-level Supervisor configuration with a minimal Invoice Ninja-owned configuration.
- Move the PHP-FPM, queue-worker, and scheduler definitions into `programs.conf`.
- Remove the unused UNIX XML-RPC/supervisorctl endpoint that emitted a `CRIT` startup diagnostic.

## Validation

- Built the Debian image locally with:
  ```sh
  docker build --tag invoiceninja-supervisor-test:local .
  ```
- Started Supervisor directly using the final image configuration.
- Confirmed Supervisor loaded programs.conf.
- Confirmed no unix_http_server/authentication CRIT diagnostic appeared.
- Confirmed /run/supervisor.sock was absent.

## Trade-off
This deliberately replaces Debian's top-level Supervisor configuration rather than inheriting it. Review the minimal configuration when upgrading the Supervisor package for any newly required global settings or path changes.