### PR TITLE
feat: make redis and mariadb accept external instances

### DIFF
--- a/charts/invoiceninja/templates/_helpers.tpl
+++ b/charts/invoiceninja/templates/_helpers.tpl
@@ -43,3 +43,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "invoiceninja.redisServiceName" -}}
 {{- printf "%s-redis" (include "invoiceninja.fullname" .) -}}
 {{- end -}}
+
+{{- define "invoiceninja.secretName" -}}
+{{- if .Values.secret.existingSecret -}}
+{{- .Values.secret.existingSecret -}}
+{{- else -}}
+{{- printf "%s-secret" (include "invoiceninja.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/invoiceninja/templates/app.yaml
+++ b/charts/invoiceninja/templates/app.yaml
@@ -34,14 +34,18 @@ spec:
             - /bin/sh
             - -c
             - |
+              {{- if .Values.mysql.enabled }}
               until nc -z {{ include "invoiceninja.mysqlServiceName" . }} {{ .Values.mysql.service.port }}; do
                 echo "waiting for mysql";
                 sleep 2;
               done
+              {{- end }}
+              {{- if .Values.redis.enabled }}
               until nc -z {{ include "invoiceninja.redisServiceName" . }} {{ .Values.redis.service.port }}; do
                 echo "waiting for redis";
                 sleep 2;
               done
+              {{- end }}
       containers:
         - name: app
           image: "{{ .Values.app.image.repository }}:{{ .Values.app.image.tag }}"
@@ -57,27 +61,27 @@ spec:
             - name: APP_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: APP_KEY
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: DB_PASSWORD
             - name: REDIS_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: REDIS_PASSWORD
             - name: IN_USER_EMAIL
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: IN_USER_EMAIL
             - name: IN_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: IN_PASSWORD
           livenessProbe:
             exec:

--- a/charts/invoiceninja/templates/configmap.yaml
+++ b/charts/invoiceninja/templates/configmap.yaml
@@ -15,14 +15,22 @@ data:
   CACHE_DRIVER: {{ .Values.env.cacheDriver | quote }}
   QUEUE_CONNECTION: {{ .Values.env.queueConnection | quote }}
   SESSION_DRIVER: {{ .Values.env.sessionDriver | quote }}
-  REDIS_HOST: {{ include "invoiceninja.redisServiceName" . | quote }}
+  {{- if or .Values.redis.enabled .Values.env.redisHost }}
+  REDIS_HOST: {{ .Values.env.redisHost | default (include "invoiceninja.redisServiceName" .) | quote }}
   REDIS_PORT: {{ .Values.env.redisPort | quote }}
+  {{- end }}
   FILESYSTEM_DISK: {{ .Values.env.filesystemDisk | quote }}
-  DB_HOST: {{ include "invoiceninja.mysqlServiceName" . | quote }}
+  {{- if or .Values.mysql.enabled .Values.env.dbHost }}
+  DB_HOST: {{ .Values.env.dbHost | default (include "invoiceninja.mysqlServiceName" .) | quote }}
   DB_PORT: {{ .Values.env.dbPort | quote }}
+  {{- end }}
   DB_DATABASE: {{ .Values.env.dbDatabase | quote }}
   DB_USERNAME: {{ .Values.env.dbUsername | quote }}
   DB_CONNECTION: {{ .Values.env.dbConnection | quote }}
+  {{- if .Values.mysql.enabled }}
+  MYSQL_DATABASE: {{ .Values.env.dbDatabase | quote }}
+  MYSQL_USER: {{ .Values.env.dbUsername | quote }}
+  {{- end }}
   MAIL_MAILER: {{ .Values.env.mailMailer | quote }}
   MAIL_HOST: {{ .Values.env.mailHost | quote }}
   MAIL_PORT: {{ .Values.env.mailPort | quote }}
@@ -31,8 +39,6 @@ data:
   MAIL_ENCRYPTION: {{ .Values.env.mailEncryption | quote }}
   MAIL_FROM_ADDRESS: {{ .Values.env.mailFromAddress | quote }}
   MAIL_FROM_NAME: {{ .Values.env.mailFromName | quote }}
-  MYSQL_DATABASE: {{ .Values.env.dbDatabase | quote }}
-  MYSQL_USER: {{ .Values.env.dbUsername | quote }}
   NORDIGEN_SECRET_ID: {{ .Values.env.nordigenSecretId | quote }}
   NORDIGEN_SECRET_KEY: {{ .Values.env.nordigenSecretKey | quote }}
   IS_DOCKER: {{ .Values.env.isDocker | quote }}

--- a/charts/invoiceninja/templates/mysql.yaml
+++ b/charts/invoiceninja/templates/mysql.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mysql.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -41,12 +42,12 @@ spec:
             - name: MYSQL_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: MYSQL_PASSWORD
             - name: MYSQL_ROOT_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: MYSQL_ROOT_PASSWORD
           livenessProbe:
             exec:
@@ -105,3 +106,4 @@ spec:
   selector:
     {{- include "invoiceninja.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: mysql
+{{- end }}

--- a/charts/invoiceninja/templates/pvc.yaml
+++ b/charts/invoiceninja/templates/pvc.yaml
@@ -34,7 +34,7 @@ spec:
   {{- end }}
 ---
 {{- end }}
-{{- if .Values.persistence.mysqlData.enabled }}
+{{- if and .Values.mysql.enabled .Values.persistence.mysqlData.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -52,7 +52,7 @@ spec:
   {{- end }}
 ---
 {{- end }}
-{{- if .Values.persistence.redisData.enabled }}
+{{- if and .Values.redis.enabled .Values.persistence.redisData.enabled }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:

--- a/charts/invoiceninja/templates/redis.yaml
+++ b/charts/invoiceninja/templates/redis.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.redis.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -32,7 +33,7 @@ spec:
             - name: REDISCLI_AUTH
               valueFrom:
                 secretKeyRef:
-                  name: {{ include "invoiceninja.fullname" . }}-secret
+                  name: {{ include "invoiceninja.secretName" . }}
                   key: REDIS_PASSWORD
           {{- end }}
           ports:
@@ -86,3 +87,4 @@ spec:
   selector:
     {{- include "invoiceninja.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: redis
+{{- end }}

--- a/charts/invoiceninja/templates/secret.yaml
+++ b/charts/invoiceninja/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.secret.existingSecret }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,9 +9,12 @@ type: Opaque
 stringData:
   APP_KEY: {{ .Values.secret.appKey | quote }}
   DB_PASSWORD: {{ .Values.secret.dbPassword | quote }}
+  REDIS_PASSWORD: {{ .Values.secret.redisPassword | quote }}
+  {{- if .Values.mysql.enabled }}
   DB_ROOT_PASSWORD: {{ .Values.secret.dbRootPassword | quote }}
   MYSQL_PASSWORD: {{ .Values.secret.dbPassword | quote }}
   MYSQL_ROOT_PASSWORD: {{ .Values.secret.dbRootPassword | quote }}
-  REDIS_PASSWORD: {{ .Values.secret.redisPassword | quote }}
+  {{- end }}
   IN_USER_EMAIL: {{ .Values.secret.inUserEmail | quote }}
   IN_PASSWORD: {{ .Values.secret.inPassword | quote }}
+{{- end }}

--- a/charts/invoiceninja/values.yaml
+++ b/charts/invoiceninja/values.yaml
@@ -79,6 +79,7 @@ nginx:
         - ALL
 
 mysql:
+  enabled: true
   image:
     repository: mariadb
     tag: "lts"
@@ -101,6 +102,7 @@ mysql:
   tolerations: []
 
 redis:
+  enabled: true
   image:
     repository: redis
     tag: alpine
@@ -164,6 +166,11 @@ secret:
   # REQUIRED: generate with `php artisan key:generate --show` or
   # openssl rand -base64 32 | sed 's/^/base64:/'
   appKey: ""
+  # Use an externally-managed Secret instead of templating these values.
+  # The Secret must provide keys: APP_KEY, DB_PASSWORD, REDIS_PASSWORD,
+  # IN_USER_EMAIL, IN_PASSWORD. When mysql.enabled=true also add:
+  # DB_ROOT_PASSWORD, MYSQL_PASSWORD, MYSQL_ROOT_PASSWORD.
+  existingSecret: ""
   dbPassword: ninja
   dbRootPassword: ninjaAdm1nPassword
   redisPassword: ""
@@ -184,8 +191,12 @@ env:
   queueConnection: redis
   sessionDriver: redis
   redisPort: "6379"
+  # redisHost: override when using an external Redis. Defaults to the internal service.
+  redisHost: ""
   filesystemDisk: debian_docker
   dbPort: "3306"
+  # dbHost: override when using an external MySQL/MariaDB. Defaults to the internal service.
+  dbHost: ""
   # dbDatabase and dbUsername are shared by both the app and the MySQL container.
   # Change both env.dbDatabase/dbUsername and secret.dbPassword together.
   dbDatabase: ninja


### PR DESCRIPTION
I wanted to use external instances of redis and mariadb with your helm chart. Here are the changes to make it happen. I wasn't sure if you were taking PRs, feel free to close this if it's not wanted.

This guards the resources via `mysql.enabled` and `redis.enabled`, so they're not added if they're not wanted. Then swaps the secret refs to the new `secret.existingSecret`, if it's provided.

Example values I'm using for this:

```
...

mysql:
  enabled: false
redis:
  enabled: false

secret:
  existingSecret: invoice-ninja

env:
  appUrl: https://<host>
  requireHttps: "true"
  dbHost: mariadb.mariadb.svc
  dbDatabase: ninja
  dbUsername: <username>
  redisHost: redis-master.redis.svc

...
```

Things seem to be fine on my end, everything deployed correctly. 